### PR TITLE
Agrego nvmrc

### DIFF
--- a/.nvmrc
+++ b/.nvmrc
@@ -1,0 +1,1 @@
+lts/gallium

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before anything else, you will need a *TypeScript* editor. We recomend [Visual S
 
 ### Node
 
-You need to install [a LTS node version](https://nodejs.org/es/) > 11, which provides VM environment, and [nvm - Node Version Manager](https://github.com/nvm-sh/nvm). Before anything make sure you'll use the right version of node by running this command:
+You need to install [a LTS node version](https://nodejs.org/es/) > 15, which provides VM environment, and [nvm - Node Version Manager](https://github.com/nvm-sh/nvm). Before anything make sure you'll use the right version of node by running this command:
 
 ```bash
 nvm use
@@ -48,8 +48,8 @@ nvm use
 Expected output is the node version that will be used, for example:
 
 ```bash
-Found '/home/dodain/workspace/wollok-dev/wollok-ts/.nvmrc' with version <v11.15.0>
-Now using node v11.15.0 (npm v6.7.0)
+Found '/home/you/wollok-ts-cli/.nvmrc' with version <lts/gallium>
+Now using node v16.15.0 (npm v8.5.5)
 ```
 
 ### NPM

--- a/README.md
+++ b/README.md
@@ -39,7 +39,7 @@ Before anything else, you will need a *TypeScript* editor. We recomend [Visual S
 
 ### Node
 
-You need to install [node](https://nodejs.org/es/) > 11, which provides VM environment, and [nvm - Node Version Manager](https://github.com/nvm-sh/nvm). Before anything make sure you'll use the right version of node by running this command:
+You need to install [a LTS node version](https://nodejs.org/es/) > 11, which provides VM environment, and [nvm - Node Version Manager](https://github.com/nvm-sh/nvm). Before anything make sure you'll use the right version of node by running this command:
 
 ```bash
 nvm use

--- a/README.md
+++ b/README.md
@@ -2,24 +2,16 @@
 
 Wollok Command Line Interface
 
+## Available Commands
 
-## Usage
-
-If you are looking at this, you are probably interested in how to use this project from a developer's point of view (for a user's point of view, please run the client with the `--help` argument to see all options).
-
-After checking-out the project run `npm install` to download all dependencies. You can run the CLI by running `npm start`. Use the `--help` flag to see all available commands and options.
-
-Remember that, while running through npm, you will need to add a `--` before any non npm related flags. For example you can run `npm start -- --help` to see the application manual.
-
-To build the CLI executables for distribution run `npm run build` and check the `/dist` folder.
-
-### Available Commands
+Wollok Command Line Interface should be run **inside a Wollok project folder**. This folder is considered as the wollok target project.
 
 This is the list of the currently available commands:
 
-- **run < program >**: Runs a Wollok program on the target project.
-- **test [ filter ]**: Runs Wollok tests on the target project.
-- **repl < auto-import >**: Opens the Wollok REPL on the target project importing the auto-import path (if any).
+- **--help**: Shows the manual with all the options
+- **run <program>**: Runs a Wollok program on the target project.
+- **test \[filter\]**: Runs Wollok tests on the target project.
+- **repl <auto-import>**: Opens the Wollok REPL on the target project importing the auto-import path (if any).
 
 ## Contributing
 
@@ -38,9 +30,11 @@ Before anything else, you will need a *TypeScript* editor. We recomend [Visual S
 - [Wollok Highlight](https://marketplace.visualstudio.com/items?itemName=uqbar.wollok-highlight)
 
 
-### Node
+### Node, npm, and dependencies
 
-You need to install [a LTS node version](https://nodejs.org/es/) > 15, which provides VM environment, and [nvm - Node Version Manager](https://github.com/nvm-sh/nvm). Before anything make sure you'll use the right version of node by running this command:
+You need to install [nvm - Node Version Manager](https://github.com/nvm-sh/nvm). 
+
+Before anything make sure you'll use the right version of node by running this command:
 
 ```bash
 nvm use
@@ -53,14 +47,16 @@ Found '/home/you/wollok-ts-cli/.nvmrc' with version <lts/gallium>
 Now using node v16.15.0 (npm v8.5.5)
 ```
 
-### NPM
+In the previous step, `nvm use` also installs [NPM](https://www.npmjs.com/). If you are not familiar with *dependency manager tools*, you can think of this program as the entry point for all the important tasks development-related tasks, like installing dependencies and running tests. 
 
-You will also need to install [NPM](https://www.npmjs.com/). (Node.js version 8 or greater) If you are not familiar with *dependency manager tools*, you can think of this program as the entry point for all the important tasks development-related tasks, like installing dependencies and running tests. After installing the client, go to the project root folder and run:
+So now you need to use npm to install dependencies:
 
 ```bash
 # This will install all the project dependencies. Give it some time.
 npm install
 ```
+
+### Running and testing
 
 After that, you are ready to start working. You can **run the tests and style checks** by typing:
 
@@ -68,3 +64,23 @@ After that, you are ready to start working. You can **run the tests and style ch
 # This will run tests for all the modules. Try to do this often and avoid commiting changes if any test fails.
 npm test
 ```
+
+You can **run the CLI** by running `npm start`. Remember that, while running through npm, you will need to add a `--` before any non npm related flags. For example, to see the application manual you can run 
+
+```bash
+npm start -- --help 
+```
+
+Another example, opening the repl on a certain file in a certain wollok project:
+
+```bash
+npm start -- repl /home/you/myWollokProject/birds.wlk -p /home/you/myWollokProject/
+```
+
+Finally, you can generate wollok-cli **executable binaries** (a.k.a. the distributable user-ready program) by running:
+
+```bash
+npm run build
+```
+
+And checking the `/dist` folder.

--- a/package-lock.json
+++ b/package-lock.json
@@ -5,7 +5,6 @@
   "requires": true,
   "packages": {
     "": {
-      "name": "wollok-ts-cli",
       "version": "0.0.1",
       "license": "MIT",
       "dependencies": {


### PR DESCRIPTION
Noté que el pkg no corría con versiones de node no LTS, así que agregué un nvmrc

![Selection_028](https://user-images.githubusercontent.com/5421992/166635407-85a17b56-810e-486a-ba85-3266381413e7.png)

```
npm run build

> wollok-ts-cli@0.0.1 build
> rm -rf dist && tsc && pkg .

> pkg@5.6.0
> Targets not specified. Assuming:
  node15-linux-x64, node15-macos-x64, node15-win-x64
> Error! No available node version satisfies 'node15'

```

Solución aquí:
https://github.com/vercel/pkg/issues/838#issuecomment-805048225