### PR TITLE
Agrego opcion 'verbose' en comando repl

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -12,6 +12,7 @@
         "chalk": "^4.1.2",
         "commander": "^9.2.0",
         "globby": "^11.0.4",
+        "loglevel": "^1.8.0",
         "wollok-ts": "^3.1.0"
       },
       "bin": {
@@ -1760,6 +1761,18 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "node_modules/loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA==",
+      "engines": {
+        "node": ">= 0.6.0"
+      },
+      "funding": {
+        "type": "tidelift",
+        "url": "https://tidelift.com/funding/github/npm/loglevel"
+      }
     },
     "node_modules/lru-cache": {
       "version": "6.0.0",
@@ -4183,6 +4196,11 @@
       "resolved": "https://registry.npmjs.org/lodash.merge/-/lodash.merge-4.6.2.tgz",
       "integrity": "sha512-0KpjqXRVvrYyCsX1swR/XTK0va6VQkQM6MNo7PqW77ByjAhoARA8EfrP1N4+KlKj8YS0ZUCtRT/YUuhyYDujIQ==",
       "dev": true
+    },
+    "loglevel": {
+      "version": "1.8.0",
+      "resolved": "https://registry.npmjs.org/loglevel/-/loglevel-1.8.0.tgz",
+      "integrity": "sha512-G6A/nJLRgWOuuwdNuA6koovfEV1YpqqAG4pRUlFaz3jj2QNZ8M4vBqnVA+HBTmU/AMNUtlOsMmSpF6NyOjztbA=="
     },
     "lru-cache": {
       "version": "6.0.0",

--- a/package.json
+++ b/package.json
@@ -19,6 +19,7 @@
     "chalk": "^4.1.2",
     "commander": "^9.2.0",
     "globby": "^11.0.4",
+    "loglevel": "^1.8.0",
     "wollok-ts": "^3.1.0"
   },
   "devDependencies": {

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -9,7 +9,7 @@ import { notEmpty } from 'wollok-ts/dist/extensions'
 import { LinkError, linkIsolated } from 'wollok-ts/dist/linker'
 import path from 'path'
 import { ParseError } from 'wollok-ts/dist/parser'
-
+import  logger  from  'loglevel'
 // TODO:
 // - autocomplete piola
 
@@ -18,6 +18,7 @@ const { log } = console
 type Options = {
   project: string
   skipValidations: boolean
+  verbose: boolean
 }
 
 export default async function (autoImportPath: string|undefined, options: Options): Promise<void> {
@@ -56,9 +57,10 @@ export default async function (autoImportPath: string|undefined, options: Option
   repl.prompt()
 }
 
-async function initializeInterpreter(autoImportPath: string|undefined, { project, skipValidations }: Options): Promise<{ imports: Import[], interpreter: Interpreter}> {
+async function initializeInterpreter(autoImportPath: string|undefined, { project, skipValidations, verbose }: Options): Promise<{ imports: Import[], interpreter: Interpreter}> {
   let environment: Environment
   const imports: Import[] = []
+  if(verbose) logger.setLevel('DEBUG')
 
   try {
     environment = await buildEnvironmentForProject(project)

--- a/src/index.ts
+++ b/src/index.ts
@@ -27,6 +27,7 @@ program.command('repl')
   .argument('[file]', 'main Wollok file to auto import')
   .option('-p, --project [filter]', 'path to project', process.cwd())
   .option('--skipValidations', 'skip code validation', false)
+  .option('-v, --verbose', 'debugging information', false)
   .action(repl)
 
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -3,8 +3,10 @@ import { readFile } from 'fs/promises'
 import globby from 'globby'
 import { join } from 'path'
 import { buildEnvironment, Environment, Problem } from 'wollok-ts'
+import  logger  from  'loglevel'
 
 const { time, timeEnd } = console
+
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 // ENVIRONMENT CREATION
@@ -13,15 +15,17 @@ const { time, timeEnd } = console
 export async function buildEnvironmentForProject(cwd: string): Promise<Environment> {
   const paths = await globby('**/*.@(wlk|wtest|wpgm)', { cwd })
 
-  time('Reading project files')
+  const debug = logger.getLevel() <= 1
+
+  if(debug) time('Reading project files')
   const files = await Promise.all(paths.map(async name =>
     ({ name, content: await readFile(join(cwd, name), 'utf8') })
   ))
-  timeEnd('Reading project files')
+  if(debug) timeEnd('Reading project files')
 
-  time('Building environment')
+  if(debug) time('Building environment')
   try { return buildEnvironment(files) }
-  finally { timeEnd('Building environment') }
+  finally { if(debug) timeEnd('Building environment' ) }
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════


### PR DESCRIPTION
Se agregaron cambios para que los mensajes de 
```
Reading project files: 0.091ms
Building environment: 257.018ms
```
solo aparezcan cuando haces wollok repl -v o wollok repl --verbose