### PR TITLE
Command repl reload errors

### DIFF
--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -85,10 +85,9 @@ async function initializeInterpreter(autoImportPath: string|undefined, { project
     }
 
   } catch (error: any) {
-    //Que errores catcheo?
     error instanceof Error && error.message == 'Exiting REPL due to validation errors!' ? log(failureDescription(error.message)) :
       log(failureDescription('Uh-oh... Unexpected TypeScript Error!', error))
-    process.exit() //Funciona ¿es feo? :q hace lo mismo
+    process.exit()
   }
   return { imports, interpreter: new Interpreter(Evaluation.build(environment!, natives)) }
 }

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -67,7 +67,7 @@ async function initializeInterpreter(autoImportPath: string|undefined, { project
       const problems = validate(environment)
       problems.forEach(problem => log(problemDescription(problem)))
       if(!problems.length) log(successDescription('No problems found building the environment!'))
-      else if(problems.some(_ => _.level === 'error')) throw new Error('Exiting REPL due to validation errors!')
+      else if(problems.some(_ => _.level === 'error')) throw problems.find(_ => _.level === 'error')
     }
 
     let autoImport: Import | undefined
@@ -85,8 +85,8 @@ async function initializeInterpreter(autoImportPath: string|undefined, { project
     }
 
   } catch (error: any) {
-    error instanceof Error && error.message == 'Exiting REPL due to validation errors!' ? log(failureDescription(error.message)) :
-      log(failureDescription('Uh-oh... Unexpected TypeScript Error!', error))
+    error.level === 'error' ? log(failureDescription('Exiting REPL due to validation errors!')) :
+      log(failureDescription('Uh-oh... Unexpected Error!', error))
     process.exit()
   }
   return { imports, interpreter: new Interpreter(Evaluation.build(environment!, natives)) }

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -89,9 +89,9 @@ async function initializeInterpreter(autoImportPath: string|undefined, { project
 
   } catch (error: any) {
     if (error.level === 'error') {
-      logger.info(failureDescription('Exiting REPL due to validation errors!'))
+      logger.error(failureDescription('Exiting REPL due to validation errors!'))
     }else{
-      logger.info(failureDescription('Uh-oh... Unexpected Error!'))
+      logger.error(failureDescription('Uh-oh... Unexpected Error!'))
       logger.debug(failureDescription('Stack trace:', error))
     }
     process.exit()

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -88,8 +88,12 @@ async function initializeInterpreter(autoImportPath: string|undefined, { project
     }
 
   } catch (error: any) {
-    error.level === 'error' ? log(failureDescription('Exiting REPL due to validation errors!')) :
-      log(failureDescription('Uh-oh... Unexpected Error!', error))
+    if (error.level === 'error') {
+      logger.info(failureDescription('Exiting REPL due to validation errors!'))
+    }else{
+      logger.info(failureDescription('Uh-oh... Unexpected Error!'))
+      logger.debug(failureDescription('Stack trace:', error))
+    }
     process.exit()
   }
   return { imports, interpreter: new Interpreter(Evaluation.build(environment!, natives)) }

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -96,7 +96,7 @@ async function initializeInterpreter(autoImportPath: string|undefined, { project
     }
     process.exit()
   }
-  return { imports, interpreter: new Interpreter(Evaluation.build(environment!, natives)) }
+  return { imports, interpreter: new Interpreter(Evaluation.build(environment, natives)) }
 }
 
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -123,7 +123,7 @@ function defineCommands( autoImportPath: string | undefined, options: Options, s
     .description('Reloads all currently imported packages and resets evaluation state')
     .allowUnknownOption()
     .action(async () => {
-      const [interpreter, imports] = await initializeInterpreter(autoImportPath, options);
+      const [interpreter, imports] = await initializeInterpreter(autoImportPath, options)
       setInterpreter(interpreter, imports)
     })
 


### PR DESCRIPTION
Respondiendo a una de las tareas pendientes en #19 este commit busca resolver el problema de que el anterior refactor generaba errores "feos" al inicializar o reiniciar el repl si el archivo a validar tenía errores.

Debo justificar la linea 90. Al final tome la decisión de hacer process.exit() ya que como deseamos imprimir el error de forma bonita, tras catchearlo y hacerlo, la función puede continuar y esto es feo porque terminas con un repl con errores, si se hace un throw falla de forma fea y si se ataja en otro lado estamos trasladando el mismo problema. Solución: hacer el equivalente a ':q' tras mostrar el error y justamente ahí se llama a process.exit() por eso es que llegué a la conclusión de que sí había que usarlo.