### PR TITLE
build script fix

### DIFF
--- a/package.json
+++ b/package.json
@@ -10,7 +10,7 @@
   },
   "main": "./build/index.js",
   "scripts": {
-    "build": "rm -rf build/* && cp -r ./src/public ./build/public && tsc",
+    "build": "rm -rf build/* && mkdir ./build && cp -r ./src/public ./build/public && tsc",
     "watch": "npm run build -- -w",
     "start": "electron ./build/index.js",
     "pack": "electron-builder"


### PR DESCRIPTION
`npm build` script requires the `./build` directory to exist, it seems this command had already been part of the script but was accidentally deleted.