### PR TITLE
Update wollok-ts v4.0.3

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -19,7 +19,7 @@
         "p5": "^1.4.2",
         "pkg": "^5.8.1",
         "socket.io": "^4.5.1",
-        "wollok-ts": "4.0.2"
+        "wollok-ts": "4.0.3"
       },
       "bin": {
         "wollok": "build/index.js"
@@ -3633,9 +3633,9 @@
       }
     },
     "node_modules/wollok-ts": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.2.tgz",
-      "integrity": "sha512-CeMW5FsnkRNSl9fh9JyQri07LueRp1xX032lwcrsd/wXv9Eu3vwhb/+D1j6L5er17I4a/Z1oJP6qDNYhiqncaQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.3.tgz",
+      "integrity": "sha512-3YjruXHZCOD3w5UkrwRAFAw5bBj6PKrHtANE8CCaNK07e8KODr+TKZOc7LKeEHvw6yA9pVcWtZwMGPiZJSUh0w==",
       "dependencies": {
         "@types/parsimmon": "^1.10.6",
         "parsimmon": "^1.18.1",
@@ -6018,9 +6018,9 @@
       }
     },
     "wollok-ts": {
-      "version": "4.0.2",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.2.tgz",
-      "integrity": "sha512-CeMW5FsnkRNSl9fh9JyQri07LueRp1xX032lwcrsd/wXv9Eu3vwhb/+D1j6L5er17I4a/Z1oJP6qDNYhiqncaQ==",
+      "version": "4.0.3",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.3.tgz",
+      "integrity": "sha512-3YjruXHZCOD3w5UkrwRAFAw5bBj6PKrHtANE8CCaNK07e8KODr+TKZOc7LKeEHvw6yA9pVcWtZwMGPiZJSUh0w==",
       "requires": {
         "@types/parsimmon": "^1.10.6",
         "parsimmon": "^1.18.1",

--- a/package.json
+++ b/package.json
@@ -44,7 +44,7 @@
     "p5": "^1.4.2",
     "pkg": "^5.8.1",
     "socket.io": "^4.5.1",
-    "wollok-ts": "4.0.2"
+    "wollok-ts": "4.0.3"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -1,6 +1,6 @@
 import { should } from 'chai'
 import { join } from 'path'
-import { Import } from 'wollok-ts'
+import { Import, Program } from 'wollok-ts'
 import { Interpreter } from 'wollok-ts/dist/interpreter/interpreter'
 import { initializeInterpreter, interprete } from '../src/commands/repl'
 import { failureDescription, successDescription, valueDescription } from '../src/utils'
@@ -14,38 +14,41 @@ describe('REPL', () => {
   const options = {
     project: projectPath,
     skipValidations: false,
+    port: '8080',
   }
   let interpreter: Interpreter
+  let replProgram: Program
   let imports: Import[]
 
   beforeEach(async () => {
-    [interpreter, imports] = await initializeInterpreter(undefined, options)
+    [interpreter, replProgram] = await initializeInterpreter(undefined, options)
+    imports = [...replProgram.parent.imports]
   })
 
   describe('should accept', () => {
 
     it('value expressions', () => {
-      const result = interprete(interpreter, imports, '1 + 2')
+      const result = interprete(interpreter, replProgram, '1 + 2')
       result.should.be.equal(successDescription('3'))
     })
 
     it('void expressions', () => {
-      const result = interprete(interpreter, imports, '[].add(1)')
+      const result = interprete(interpreter, replProgram, '[].add(1)')
       result.should.be.equal(successDescription(''))
     })
 
     it('import sentences', () => {
-      const result = interprete(interpreter, imports, 'import wollok.game.*')
+      const result = interprete(interpreter, replProgram, 'import wollok.game.*')
       result.should.be.equal(successDescription(''))
     })
 
     it('not parsing strings', () => {
-      const result = interprete(interpreter, imports, '3kd3id9')
+      const result = interprete(interpreter, replProgram, '3kd3id9')
       result.should.includes('Syntax error')
     })
 
     it('failure expressions', () => {
-      const result = interprete(interpreter, imports, 'fakeReference')
+      const result = interprete(interpreter, replProgram, 'fakeReference')
       result.should.be.equal(failureDescription(`Unknown reference ${valueDescription('fakeReference')}`))
     })
   })
@@ -53,47 +56,47 @@ describe('REPL', () => {
   describe('should print result', () => {
 
     it('for reference to wko', () => {
-      const result = interprete(interpreter, imports, 'assert')
+      const result = interprete(interpreter, replProgram, 'assert')
       result.should.be.equal(successDescription('assert'))
     })
 
     it('for reference to an instance', () => {
-      const result = interprete(interpreter, imports, 'new Object()')
+      const result = interprete(interpreter, replProgram, 'new Object()')
       result.should.be.equal(successDescription('an Object'))
     })
 
     it('for reference to a literal object', () => {
-      const result = interprete(interpreter, imports, 'object { } ')
+      const result = interprete(interpreter, replProgram, 'object { } ')
       result.should.include('an Object#')
     })
 
     it('for number', () => {
-      const result = interprete(interpreter, imports, '3')
+      const result = interprete(interpreter, replProgram, '3')
       result.should.be.equal(successDescription('3'))
     })
 
     it('for string', () => {
-      const result = interprete(interpreter, imports, '"hola"')
+      const result = interprete(interpreter, replProgram, '"hola"')
       result.should.be.equal(successDescription('"hola"'))
     })
 
     it('for boolean', () => {
-      const result = interprete(interpreter, imports, 'true')
+      const result = interprete(interpreter, replProgram, 'true')
       result.should.be.equal(successDescription('true'))
     })
 
     it('for list', () => {
-      const result = interprete(interpreter, imports, '[1, 2, 3]')
+      const result = interprete(interpreter, replProgram, '[1, 2, 3]')
       result.should.be.equal(successDescription('[1, 2, 3]'))
     })
 
     it('for set', () => {
-      const result = interprete(interpreter, imports, '#{1, 2, 3}')
+      const result = interprete(interpreter, replProgram, '#{1, 2, 3}')
       result.should.be.equal(successDescription('#{1, 2, 3}'))
     })
 
     it('for closure', () => {
-      const result = interprete(interpreter, imports, '{1 + 2}')
+      const result = interprete(interpreter, replProgram, '{1 + 2}')
       result.should.be.equal(successDescription('{1 + 2}'))
     })
   })
@@ -103,7 +106,8 @@ describe('REPL', () => {
     const fileName = join(projectPath, 'aves.wlk')
 
     beforeEach(async () => {
-      [interpreter, imports] = await initializeInterpreter(fileName, options)
+      [interpreter, replProgram] = await initializeInterpreter(fileName, options)
+      imports = [...replProgram.parent.imports]
     })
 
     it('should auto import the file and imported entities', () => {
@@ -113,19 +117,38 @@ describe('REPL', () => {
     })
 
     it('file definitions should be accessible', () => {
-      const result = interprete(interpreter, imports, 'pepita')
+      const result = interprete(interpreter, replProgram, 'pepita')
       result.should.be.equal(successDescription('pepita'))
     })
 
     it('imported definitions should be accessible', () => {
-      const result = interprete(interpreter, imports, 'alpiste')
+      const result = interprete(interpreter, replProgram, 'alpiste')
       result.should.be.equal(successDescription('alpiste'))
     })
 
+    it('not imported definitions should not be accessible', () => {
+      const result = interprete(interpreter, replProgram, 'ash')
+      result.should.be.equal(failureDescription(`Unknown reference ${valueDescription('ash')}`))
+    })
+
+    it('after generic import, definitions should be accessible', () => {
+      const result = interprete(interpreter, replProgram, 'import otros.personas.entrenadores.*')
+      result.should.be.equal(successDescription(''))
+      const result2 = interprete(interpreter, replProgram, 'ash')
+      result2.should.be.equal(successDescription('ash'))
+    })
+
+    it('after entity import, it should be accessible', () => {
+      const result = interprete(interpreter, replProgram, 'import otros.personas.entrenadores.ash')
+      result.should.be.equal(successDescription(''))
+      const result2 = interprete(interpreter, replProgram, 'ash')
+      result2.should.be.equal(successDescription('ash'))
+    })
+
     it('can be initialized with sub-folders file', async () => {
-      [interpreter, imports] = await initializeInterpreter(join(projectPath, 'otros', 'personas', 'entrenadores'), options)
-      imports.should.be.have.lengthOf(1)
-      const result = interprete(interpreter, imports, 'ash')
+      [interpreter, replProgram] = await initializeInterpreter(join(projectPath, 'otros', 'personas', 'entrenadores'), options)
+      replProgram.parent.imports.should.be.have.lengthOf(1)
+      const result = interprete(interpreter, replProgram, 'ash')
       result.should.be.equal(successDescription('ash'))
 
     })
@@ -138,7 +161,7 @@ describe('REPL', () => {
     })
 
     it('global definitions should be accessible', () => {
-      const result = interprete(interpreter, imports, 'assert')
+      const result = interprete(interpreter, replProgram, 'assert')
       result.should.be.equal(successDescription('assert'))
     })
   })


### PR DESCRIPTION
En [este PR](https://github.com/uqbar-project/wollok-ts/pull/153/files#diff-9d9322717fe9b101966134cc54128da10d71ebdcbad50cbb33f775c55e64b553L162) se sacaron cosas de más que se necesitaban acá.

Por ahora adapté la lógica en este lugar (ya que era el único que lo usaba), pero lo que necesitamos es pensar bien la API que necesitamos de TS.