### PR TITLE
Fix #58 port already used

### DIFF
--- a/public/diagram/diagram.js
+++ b/public/diagram/diagram.js
@@ -125,7 +125,7 @@ function updateNodes(elements) {
 }
 
 function objectsPositionChanged() {
-  const newTitle = objectsKeepTheirPosition() ? 'ON -> objects will keep their positions' : 'OFF -> objects will be relocated to fit into the graph layout'
+  const newTitle = objectsKeepTheirPosition() ? 'ON -> objects will keep their positions (better performance when you have > 100 objects)' : 'OFF -> objects will be relocated to fit into the graph layout (graph is easier to read)'
   document.getElementById('toggle-pin').setAttribute('title', `Fix objects position: ${newTitle}`)
 }
 

--- a/public/diagram/index.html
+++ b/public/diagram/index.html
@@ -34,7 +34,8 @@
       <script type="module">
         import { io } from "./lib/socket.io.esm.min.js";
 
-        const socket = io("http://localhost:3000");
+        const { port } = window.location
+        const socket = io(`http://localhost:${port}`);
         socket.on("connect", function () {
           console.log("conectado!");
         });

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -67,11 +67,13 @@ export default async function (autoImportPath: string | undefined, options: Opti
     })
 
   io.on('connection', socket => {
+    logger.info(successDescription('Dynamic diagram available at: ' + bold(`http://localhost:${options.port}`)))
+    repl.prompt()
+  })
+  io.on('connection', socket => {
     socket.emit('initDiagram', options)
     socket.emit('updateDiagram', getDataDiagram(interpreter))
   })
-  logger.info(successDescription('Dynamic diagram available at: ' + bold(`http://localhost:${options.port}`)))
-  repl.prompt()
 }
 
 export async function initializeInterpreter(autoImportPath: string | undefined, { project, skipValidations }: Options): Promise<Interpreter> {

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -70,6 +70,7 @@ export default async function (autoImportPath: string | undefined, options: Opti
     socket.emit('initDiagram', options)
     socket.emit('updateDiagram', getDataDiagram(interpreter))
   })
+  logger.info(successDescription('Dynamic diagram available at: ' + bold(`http://localhost:${options.port}`)))
   repl.prompt()
 }
 
@@ -224,9 +225,11 @@ async function initializeClient(options: Options) {
   server.addListener('error', ({ port, code }: { port: string, code: string }) => {
     console.info('')
     if (code === 'EADDRINUSE') {
-      console.info(yellow(bold(`Ya tenés levantado un REPL en el puerto ${port}. Si querés levantar otra instancia, utilizá la opción '--new'.`)))
+      console.info(yellow(bold(`⚡ We couldn't start dynamic diagram at port ${port}, because it is already in use. ⚡`)))
+      // eslint-disable-next-line @typescript-eslint/quotes
+      console.info(yellow(`Please make sure you don't have another REPL session running in another terminal. \nIf you want to start another instance, you can use "--port xxxx" option, where xxxx should be any available port.`))
     } else {
-      console.info(yellow(bold(`No se pudo levantar el REPL en el puerto ${port}, por un código de error "${code}.`)))
+      console.info(yellow(bold(`⚡ REPL couldn't be started at port ${port}, error code ["${code}]. ⚡`)))
     }
     process.exit(1)
   })
@@ -234,16 +237,14 @@ async function initializeClient(options: Options) {
   const io = new Server(server)
 
   io.on('connection', socket => {
-    logger.info(successDescription('Connected to Dynamic diagram'))
-    socket.on('disconnect', () => { logger.info(failureDescription('Dynamic diagram closed')) })
+    logger.debug(successDescription('Connected to Dynamic diagram'))
+    socket.on('disconnect', () => { logger.debug(failureDescription('Dynamic diagram closed')) })
   })
   app.use(
     cors({ allowedHeaders: '*' }),
     express.static(publicPath('diagram'), { maxAge: '1d' }),
   )
   server.listen(parseInt(options.port), 'localhost')
-
-  logger.info(successDescription('Dynamic diagram available at: ' + bold(`http://localhost:${options.port}`)))
   return io
 }
 

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -1,4 +1,4 @@
-import { bold } from 'chalk'
+import { bold, yellow } from 'chalk'
 import { Command } from 'commander'
 import cors from 'cors'
 import express from 'express'
@@ -70,7 +70,6 @@ export default async function (autoImportPath: string | undefined, options: Opti
     socket.emit('initDiagram', options)
     socket.emit('updateDiagram', getDataDiagram(interpreter))
   })
-
   repl.prompt()
 }
 
@@ -221,6 +220,17 @@ async function autocomplete(input: string): Promise<CompleterResult> {
 async function initializeClient(options: Options) {
   const app = express()
   const server = http.createServer(app)
+
+  server.addListener('error', ({ port, code }: { port: string, code: string }) => {
+    console.info('')
+    if (code === 'EADDRINUSE') {
+      console.info(yellow(bold(`Ya tenés levantado un REPL en el puerto ${port}. Si querés levantar otra instancia, utilizá la opción '--new'.`)))
+    } else {
+      console.info(yellow(bold(`No se pudo levantar el REPL en el puerto ${port}, por un código de error "${code}.`)))
+    }
+    process.exit(1)
+  })
+
   const io = new Server(server)
 
   io.on('connection', socket => {


### PR DESCRIPTION
En este PR metemos algunas cositas:

- escuchamos el evento 'error' para que si el REPL no puede levantar el diagrama dinámico en el 3000 te tire un mensaje copado
- de paso, si hay otro tipo de error también mostramos un mensaje
- la alternativa es que le pases un puerto distinto: `--port xxxx` y eso está aclarado en el mensaje de error "copado"
- la página del diagrama hardcodeaba el puerto 3000 con lo cual daba un error de CORS al conectarse con el server (igual lo que iba a hacer era espejar el diagrama del 3000 en otras páginas). Ahora podés tener n REPLs con sus correspondientes diagramas dinámicos, una locura (no se para qué pero se puede)
- y también deshabilitamos mensajes que aparecían cada dos por tres en el REPL diciendo que se conectaba/desconectaba el diagrama dinámico. Esto es esperable vía socket, porque timeoutea y después se reconecta solito.

Va una demo para @JuanFdS @asanzo y la muchachada

![dynamicDiagramDuo](https://github.com/uqbar-project/wollok-ts-cli/assets/4549002/e89fa452-a619-410b-9342-b55be9071471)

De paso le metí una mejora a la explicación del toggle que hace que los objetos se reubiquen o no.