### PR TITLE
fix: preinstall script (#100)

### DIFF
--- a/scripts/download-libs.sh
+++ b/scripts/download-libs.sh
@@ -2,11 +2,11 @@ LIB_FOLDER=./public/diagram/lib
 
 # socket.io
 if [ ! -f $LIB_FOLDER/socket.io.esm.min.js ]; then
-    wget -P $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js"
-    wget -P $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js.map"
+     curl -O --create-dirs --output-dir $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js"
+     curl -O --create-dirs --output-dir $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js.map"
 fi
 
 # cytoscape
 if [ ! -f $LIB_FOLDER/cytoscape.min.js ]; then
-    wget -P $LIB_FOLDER "https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.26.0/cytoscape.min.js"
+    curl -O --create-dirs --output-dir $LIB_FOLDER "https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.26.0/cytoscape.min.js"
 fi


### PR DESCRIPTION
The preinstall script failed on win systems because 'wget' isn't available. So, an easy fix is to replace it with curl, ensuring that with the specified parameters, the desired behavior is maintained.

Something I'd like to point out is that on Windows, to execute the installation script, one would need to use a bash emulator. This is because running sh scripts directly through PowerShell requires some workaround tricks.