### PR TITLE
fix: version command (#99)

### DIFF
--- a/scripts/download-libs.sh
+++ b/scripts/download-libs.sh
@@ -2,11 +2,11 @@ LIB_FOLDER=./public/diagram/lib
 
 # socket.io
 if [ ! -f $LIB_FOLDER/socket.io.esm.min.js ]; then
-    wget -P $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js"
-    wget -P $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js.map"
+     curl -O --create-dirs --output-dir $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js"
+     curl -O --create-dirs --output-dir $LIB_FOLDER "https://cdn.socket.io/4.4.1/socket.io.esm.min.js.map"
 fi
 
 # cytoscape
 if [ ! -f $LIB_FOLDER/cytoscape.min.js ]; then
-    wget -P $LIB_FOLDER "https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.26.0/cytoscape.min.js"
+    curl -O --create-dirs --output-dir $LIB_FOLDER "https://cdnjs.cloudflare.com/ajax/libs/cytoscape/3.26.0/cytoscape.min.js"
 fi

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,12 @@ import run from './commands/run'
 import test from './commands/test'
 import init from './commands/init'
 import logger from 'loglevel'
+import { version } from  '../package.json'
 
 const program = new Command()
   .name('wollok')
   .description('Wollok Language command line interpreter tool')
-  .version(process.env.npm_package_version ?? 'unkown')
+  .version(version)
   .hook('preAction', (thisCommand, actionCommand) =>  {
     actionCommand.opts().verbose ? logger.setLevel('DEBUG') : logger.setLevel('INFO')
   })


### PR DESCRIPTION
Se arregla la versión command que estaba tirando unknown en vez del numero correspondiente Por lo que vi, la env variable está definida si y solo si se corre el programa con node, como se corre como binario/executable no la encuentra.