### PR TITLE
fix: version command (#99)

### DIFF
--- a/src/index.ts
+++ b/src/index.ts
@@ -5,11 +5,13 @@ import test from './commands/test'
 import init from './commands/init'
 import logger from 'loglevel'
 import { version } from  '../package.json'
+import { cyan } from 'chalk'
+
 
 const program = new Command()
   .name('wollok')
   .description('Wollok Language command line interpreter tool')
-  .version(version)
+  .version(cyan(version))
   .hook('preAction', (thisCommand, actionCommand) =>  {
     actionCommand.opts().verbose ? logger.setLevel('DEBUG') : logger.setLevel('INFO')
   })

--- a/src/index.ts
+++ b/src/index.ts
@@ -4,11 +4,12 @@ import run from './commands/run'
 import test from './commands/test'
 import init from './commands/init'
 import logger from 'loglevel'
+import { version } from  '../package.json'
 
 const program = new Command()
   .name('wollok')
   .description('Wollok Language command line interpreter tool')
-  .version(process.env.npm_package_version ?? 'unkown')
+  .version(version)
   .hook('preAction', (thisCommand, actionCommand) =>  {
     actionCommand.opts().verbose ? logger.setLevel('DEBUG') : logger.setLevel('INFO')
   })


### PR DESCRIPTION
Se arregla la versión command que estaba tirando unknown en vez del numero correspondiente Por lo que vi, la env variable está definida si y solo si se corre el programa con node, como se corre como binario/executable no la encuentra.