### PR TITLE
Fix repl scopes

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "p5": "^1.4.2",
         "pkg": "^5.8.1",
         "socket.io": "^4.5.1",
-        "wollok-ts": "4.0.4"
+        "wollok-ts": "4.0.5"
       },
       "bin": {
         "wollok": "build/index.js"
@@ -3634,9 +3634,9 @@
       }
     },
     "node_modules/wollok-ts": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.4.tgz",
-      "integrity": "sha512-ncuryLXHCYEexw8tjmmxDqPnt1xaM/+EHYkPRXWHad0FTWUxX+lf6QQq0fT3sG/eWWmsMX6ULkPUe/14nPjKTA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.5.tgz",
+      "integrity": "sha512-nE9M3YNDYuIA6VLhSWpwRFniESHG3GDi3t2n5y3W5nYQ/b5qDUjx9ahgoid/38Hfg9TVQH33g44ZrwrJS9axyQ==",
       "dependencies": {
         "@types/parsimmon": "^1.10.6",
         "parsimmon": "^1.18.1",
@@ -6020,9 +6020,9 @@
       }
     },
     "wollok-ts": {
-      "version": "4.0.4",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.4.tgz",
-      "integrity": "sha512-ncuryLXHCYEexw8tjmmxDqPnt1xaM/+EHYkPRXWHad0FTWUxX+lf6QQq0fT3sG/eWWmsMX6ULkPUe/14nPjKTA==",
+      "version": "4.0.5",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.5.tgz",
+      "integrity": "sha512-nE9M3YNDYuIA6VLhSWpwRFniESHG3GDi3t2n5y3W5nYQ/b5qDUjx9ahgoid/38Hfg9TVQH33g44ZrwrJS9axyQ==",
       "requires": {
         "@types/parsimmon": "^1.10.6",
         "parsimmon": "^1.18.1",

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wollok-ts-cli",
-  "version": "0.0.5",
+  "version": "0.1.0",
   "lockfileVersion": 2,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-ts-cli",
-      "version": "0.0.5",
+      "version": "0.1.0",
       "hasInstallScript": true,
       "license": "MIT",
       "dependencies": {

--- a/package.json
+++ b/package.json
@@ -46,7 +46,7 @@
     "p5": "^1.4.2",
     "pkg": "^5.8.1",
     "socket.io": "^4.5.1",
-    "wollok-ts": "4.0.4"
+    "wollok-ts": "4.0.5"
   },
   "devDependencies": {
     "@types/chai": "^4.3.4",

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -17,8 +17,6 @@ import { buildEnvironmentForProject, failureDescription, getFQN, problemDescript
 
 export const REPL = 'REPL'
 
-const replSentences: Sentence[] = []
-
 // TODO:
 // - autocomplete piola
 
@@ -256,7 +254,6 @@ async function initializeClient(options: Options) {
 function linkSentence<S extends Sentence>(newSentence: S, environment: Environment) {
   // This is a fake linking, TS should give us a better API
   const { scope } = replNode(environment)
-  replSentences.push(newSentence)
   newSentence.forEach(node => Object.assign(node, { scope, environment }))
   scope.register(...scopeContribution(newSentence))
 }

--- a/src/services/diagram-generator.ts
+++ b/src/services/diagram-generator.ts
@@ -2,7 +2,7 @@ import { ElementDefinition } from 'cytoscape'
 import { Entity, Import, InnerValue, Package, RuntimeObject } from 'wollok-ts'
 import { Interpreter } from 'wollok-ts/dist/interpreter/interpreter'
 import { REPL, replNode } from '../commands/repl'
-import { isConstant } from '../utils'
+import { isConstant, isREPLConstant } from '../utils'
 
 type objectType = 'literal' | 'object' | 'null'
 
@@ -75,10 +75,8 @@ function buildReplElement(obj: RuntimeObject, name: string) {
         id: `${REPL}_${Math.random() * 100000000}`,
         source: replId,
         target: obj.id,
-        // No funciona sacar la constante
-        // label: `${name}${isConstant(obj, name) ? '🔒' : ''}`,
         width: 1.5,
-        label: name,
+        label: `${name}${isREPLConstant(obj.module.environment, name) ? '🔒' : ''}`,
         style: 'solid',
         fontsize: getFontSize(name),
       },

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -117,11 +117,8 @@ export function linkSentence<S extends Sentence>(newSentence: S, environment: En
 }
 // Duplicated from TS
 const scopeContribution = (contributor: Node): List<[Name, Node]> => {
-  if (
-    contributor.is(Entity) ||
-    contributor.is(Field) ||
-    contributor.is(Parameter)
-  ) return contributor.name ? [[contributor.name, contributor]] : []
-
+  if (canBeReferenced(contributor))
+    return contributor.name ? [[contributor.name, contributor]] : []
   return []
 }
+const canBeReferenced = (node: Node): node is Entity | Field | Parameter => node.is(Entity) || node.is(Field) || node.is(Parameter)

--- a/test/diagram.test.ts
+++ b/test/diagram.test.ts
@@ -1,10 +1,9 @@
 import { should, use } from 'chai'
 import { join } from 'path'
 import { Interpreter } from 'wollok-ts/dist/interpreter/interpreter'
-import { initializeInterpreter } from '../src/commands/repl'
+import { initializeInterpreter, interprete } from '../src/commands/repl'
 import { getDataDiagram } from '../src/services/diagram-generator'
 import { diagramAssertions } from './assertions'
-import { Variable } from 'wollok-ts'
 
 use(diagramAssertions)
 should()
@@ -68,17 +67,22 @@ describe('Dynamic diagram', () => {
   })
 
   it('should include the REPL object', () => {
-    interpreter.exec(new Variable({ isConstant: false, name: 'x' }))
+    interprete(interpreter, 'var x')
     getDataDiagram(interpreter).should.include.nodeWith({ label: 'REPL', type: 'REPL' })
   })
 
   it('should include edges between REPL and WKOs', () => {
-    interpreter.exec(new Variable({ isConstant: false, name: 'x' }))
+    interprete(interpreter, 'var x')
     getDataDiagram(interpreter).should.connect('x', 'REPL', 'null')
   })
 
+  it('should include constant edges between REPL and WKOs', () => {
+    interprete(interpreter, 'const x = 7')
+    getDataDiagram(interpreter).should.connect('x🔒', 'REPL', '7')
+  })
+
   it('should have a specific type for null object', () => {
-    interpreter.exec(new Variable({ isConstant: false, name: 'x' }))
+    interprete(interpreter, 'var x')
     getDataDiagram(interpreter).should.include.nodeWith({ label: 'null', type: 'null' })
   })
 

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -55,6 +55,12 @@ describe('REPL', () => {
       result.should.includes(failureDescription('Evaluation Error!'))
     })
 
+    // TODO: Change the Runtime model
+    xit('const const', () => {
+      interprete(interpreter, 'const a = 1')
+      const result = interprete(interpreter, 'const a = 2')
+      result.should.includes(failureDescription('Evaluation Error!'))
+    })
   })
 
   describe('should print result', () => {

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -48,6 +48,13 @@ describe('REPL', () => {
       const result = interprete(interpreter, 'fakeReference')
       result.should.be.equal(failureDescription(`Unknown reference ${valueDescription('fakeReference')}`))
     })
+
+    it('const assignment', () => {
+      interprete(interpreter, 'const a = 1')
+      const result = interprete(interpreter, 'a = 2')
+      result.should.includes(failureDescription('Evaluation Error!'))
+    })
+
   })
 
   describe('should print result', () => {

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -22,62 +22,70 @@ describe('REPL', () => {
     interpreter = await initializeInterpreter(undefined, options)
   )
 
-  describe('should accept', () => {
-
-    it('value expressions', () => {
-      const result = interprete(interpreter, '1 + 2')
-      result.should.be.equal(successDescription('3'))
-    })
-
-    it('void expressions', () => {
-      const result = interprete(interpreter, '[].add(1)')
-      result.should.be.equal(successDescription(''))
-    })
-
-    it('import sentences', () => {
-      const result = interprete(interpreter, 'import wollok.game.*')
-      result.should.be.equal(successDescription(''))
-    })
-
-    it('const sentences', () => {
-      const result = interprete(interpreter, 'const a = 1')
-      result.should.be.equal(successDescription(''))
-      const result2 = interprete(interpreter, 'a')
-      result2.should.be.equal(successDescription('1'))
-    })
-
-    it('var sentences', () => {
-      const result = interprete(interpreter, 'var a = 1')
-      result.should.be.equal(successDescription(''))
-      const result2 = interprete(interpreter, 'a = 2')
-      result2.should.be.equal(successDescription(''))
-      const result3 = interprete(interpreter, 'a')
-      result3.should.be.equal(successDescription('2'))
-    })
-
-    it('not parsing strings', () => {
-      const result = interprete(interpreter, '3kd3id9')
-      result.should.includes('Syntax error')
-    })
-
-    it('failure expressions', () => {
-      const result = interprete(interpreter, 'fakeReference')
-      result.should.be.equal(failureDescription(`Unknown reference ${valueDescription('fakeReference')}`))
-    })
-
-    it('const assignment', () => {
-      interprete(interpreter, 'const a = 1')
-      const result = interprete(interpreter, 'a = 2')
-      result.should.includes(failureDescription('Evaluation Error!'))
-    })
-
-    // TODO: Change the Runtime model
-    xit('const const', () => {
-      interprete(interpreter, 'const a = 1')
-      const result = interprete(interpreter, 'const a = 2')
-      result.should.includes(failureDescription('Evaluation Error!'))
-    })
+  it('value expressions', () => {
+    const result = interprete(interpreter, '1 + 2')
+    result.should.be.equal(successDescription('3'))
   })
+
+  it('void expressions', () => {
+    const result = interprete(interpreter, '[].add(1)')
+    result.should.be.equal(successDescription(''))
+  })
+
+  it('import sentences', () => {
+    const result = interprete(interpreter, 'import wollok.game.*')
+    result.should.be.equal(successDescription(''))
+  })
+
+  it('const sentences', () => {
+    const result = interprete(interpreter, 'const a = 1')
+    result.should.be.equal(successDescription(''))
+    const result2 = interprete(interpreter, 'a')
+    result2.should.be.equal(successDescription('1'))
+  })
+
+  it('var sentences', () => {
+    const result = interprete(interpreter, 'var a = 1')
+    result.should.be.equal(successDescription(''))
+    const result2 = interprete(interpreter, 'a = 2')
+    result2.should.be.equal(successDescription(''))
+    const result3 = interprete(interpreter, 'a')
+    result3.should.be.equal(successDescription('2'))
+  })
+
+  it('block without parameters', () => {
+    const result = interprete(interpreter, '{ 1 }.apply()')
+    result.should.be.equal(successDescription('1'))
+  })
+
+  it('block with parameters', () => {
+    const result = interprete(interpreter, '{ x => x + 1 }.apply(1)')
+    result.should.be.equal(successDescription('2'))
+  })
+
+  it('not parsing strings', () => {
+    const result = interprete(interpreter, '3kd3id9')
+    result.should.includes('Syntax error')
+  })
+
+  it('failure expressions', () => {
+    const result = interprete(interpreter, 'fakeReference')
+    result.should.be.equal(failureDescription(`Unknown reference ${valueDescription('fakeReference')}`))
+  })
+
+  it('const assignment', () => {
+    interprete(interpreter, 'const a = 1')
+    const result = interprete(interpreter, 'a = 2')
+    result.should.includes(failureDescription('Evaluation Error!'))
+  })
+
+  // TODO: Change the Runtime model
+  xit('const const', () => {
+    interprete(interpreter, 'const a = 1')
+    const result = interprete(interpreter, 'const a = 2')
+    result.should.includes(failureDescription('Evaluation Error!'))
+  })
+
 
   describe('should print result', () => {
 

--- a/test/repl.test.ts
+++ b/test/repl.test.ts
@@ -39,6 +39,22 @@ describe('REPL', () => {
       result.should.be.equal(successDescription(''))
     })
 
+    it('const sentences', () => {
+      const result = interprete(interpreter, 'const a = 1')
+      result.should.be.equal(successDescription(''))
+      const result2 = interprete(interpreter, 'a')
+      result2.should.be.equal(successDescription('1'))
+    })
+
+    it('var sentences', () => {
+      const result = interprete(interpreter, 'var a = 1')
+      result.should.be.equal(successDescription(''))
+      const result2 = interprete(interpreter, 'a = 2')
+      result2.should.be.equal(successDescription(''))
+      const result3 = interprete(interpreter, 'a')
+      result3.should.be.equal(successDescription('2'))
+    })
+
     it('not parsing strings', () => {
       const result = interprete(interpreter, '3kd3id9')
       result.should.includes('Syntax error')


### PR DESCRIPTION
Fix #108 
Resuelve parte de https://github.com/uqbar-project/wollok-ts-cli/issues/90

- Fix de `const x = 1` y `x = 2` en el REPL
- Fix del candadito en las referencias del REPL en el diagrama
- Me tuve que traer cosas de TS, hay que mejorar la interfaz de linkeo -> Es lo que falta del issue

![telegram-cloud-photo-size-1-5026018056480074699-x](https://github.com/uqbar-project/wollok-ts-cli/assets/4098184/111ff948-74ee-4220-81d4-3444bc67b509)
