### PR TITLE
Pre wollok ts migration

### DIFF
--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -113,6 +113,7 @@ export async function initializeInterpreter(autoImportPath: string | undefined, 
     validateEnvironment(environment, skipValidations)
 
     if (autoImportPath) {
+      // TODO: migrate to wollok-ts?? at least up to line 120
       const fqn = getFQN(project, autoImportPath)
       const entity = environment.getNodeOrUndefinedByFQN<Entity>(fqn)
       if (entity && entity.is(Package)) {
@@ -296,6 +297,7 @@ export async function initializeClient(options: Options, repl: Interface, interp
   }
 }
 
+// TODO: migrate to wollok-ts
 function newImport(importNode: Import, environment: Environment) {
   const node = replNode(environment)
   const imported = node.scope.resolve<Package | Entity>(importNode.entity.name)!
@@ -305,4 +307,5 @@ function newImport(importNode: Import, environment: Environment) {
   return node.scope.register([imported.name!, imported])
 }
 
+// TODO: migrate to wollok-ts
 export const replNode = (environment: Environment): Package => environment.getNodeByFQN<Package>(REPL)

--- a/src/commands/repl.ts
+++ b/src/commands/repl.ts
@@ -193,6 +193,8 @@ function defineCommands(autoImportPath: string | undefined, options: Options, re
 
 export function interprete(interpreter: Interpreter, line: string): string {
   try {
+    // TODO: migrate to wollok-ts???
+    // Decouple 1. interpreter should link sentence, or add a new import, and repl should process the result and catch errors
     const sentenceOrImport = parse.Import.or(parse.Variable).or(parse.Assignment).or(parse.Expression).tryParse(line)
     const error = [sentenceOrImport, ...sentenceOrImport.descendants].flatMap(_ => _.problems ?? []).find(_ => _.level === 'error')
     if (error) throw error

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -25,7 +25,7 @@ export function sanitize(value?: string): string | undefined {
   return value?.replaceAll('"', '')
 }
 
-// TODO: migrate to wollok-ts (getTestsToRun)
+// TODO: migrate to wollok-ts (testRunner.run -> could return a list of test results)
 export function getTarget(environment: Environment, filter: string | undefined, { file, describe, test }: Options): Test[] {
   const fqnByOptionalParameters = [file, describe, test].filter(Boolean).join('.')
   const filterTest = sanitize(filter) ?? fqnByOptionalParameters ?? ''
@@ -49,6 +49,7 @@ export default async function (filter: string | undefined, options: Options): Pr
     const environment = await buildEnvironmentForProject(project)
     validateEnvironment(environment, skipValidations)
 
+    // TODO: this call and failures...
     const targets = getTarget(environment, filter, options)
 
     logger.info(`Running ${targets.length} tests...`)

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -25,6 +25,7 @@ export function sanitize(value?: string): string | undefined {
   return value?.replaceAll('"', '')
 }
 
+// TODO: migrate to wollok-ts (getTestsToRun)
 export function getTarget(environment: Environment, filter: string | undefined, { file, describe, test }: Options): Test[] {
   const fqnByOptionalParameters = [file, describe, test].filter(Boolean).join('.')
   const filterTest = sanitize(filter) ?? fqnByOptionalParameters ?? ''

--- a/src/services/diagram-generator.ts
+++ b/src/services/diagram-generator.ts
@@ -6,10 +6,12 @@ import { isConstant, isREPLConstant } from '../utils'
 
 type objectType = 'literal' | 'object' | 'null'
 
+// TODO: migrate to wollok-ts
 const LIST_MODULE = 'List'
 const STRING_MODULE = 'wollok.lang.String'
 const WOLLOK_BASE_MODULES = 'wollok.'
 
+// TODO: migrate to wollok-ts
 const SELF = 'self'
 
 function getImportedDefinitions(interpreter: Interpreter, rootFQN?: Package): Entity[] {
@@ -164,6 +166,7 @@ function shouldShortenRepresentation(moduleName: string) {
 }
 
 function shouldShowInnerValue(moduleName: string) {
+  // TODO: migrate to wollok-ts (use constants for String, number & Boolean, the function `shouldShowInnerValue` should remain here)
   return ['wollok.lang.String', 'wollok.lang.Number', 'wollok.lang.Boolean'].includes(moduleName)
 }
 

--- a/src/utils.ts
+++ b/src/utils.ts
@@ -126,14 +126,17 @@ export const isImageFile = (file: Dirent): boolean => imageExtensions.some(ext =
 // WOLLOK AST
 // ══════════════════════════════════════════════════════════════════════════════════════════════════════════════════
 
+// TODO: migrate to wollok-ts (could it be in RuntimeObject? Or at least in a helper function)
 export function isConstant(obj: RuntimeObject, localName: string): boolean {
   return obj.module.lookupField(localName)?.isConstant ?? false
 }
 
+// TODO: migrate to wollok-ts
 export function isREPLConstant(environment: Environment, localName: string): boolean {
   return replNode(environment).scope.resolve<Variable>(localName)?.isConstant ?? false
 }
 
+// TODO: migrate to wollok-ts
 // This is a fake linking, TS should give us a better API
 export function linkSentence<S extends Sentence>(newSentence: S, environment: Environment): void {
   const { scope } = replNode(environment)
@@ -144,6 +147,8 @@ export function linkSentence<S extends Sentence>(newSentence: S, environment: En
     return localScope
   }, scope)
 }
+
+// TODO: migrate to wollok-ts
 // Duplicated from TS
 const scopeContribution = (contributor: Node): List<[Name, Node]> => {
   if (canBeReferenced(contributor))


### PR DESCRIPTION
- En este PR solamente decimos lo que tendríamos que migrar.
- Un segundo paso implicaría escribir las abstracciones en Wollok TS, junto con los tests
- El tercer paso es generar un release de Wollok TS
- El cuarto es apuntar a la nueva versión de Wollok TS desde Wollok TS CLI y refactorizar código con sus tests