### PR TITLE
Releasing 0.2.0 & upgrading wollok-ts dependency

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -20,7 +20,7 @@
         "p5": "^1.8.0",
         "pkg": "^5.8.1",
         "socket.io": "^4.5.1",
-        "wollok-ts": "4.0.5"
+        "wollok-ts": "4.0.6"
       },
       "bin": {
         "wollok": "build/src/index.js"
@@ -1216,8 +1216,9 @@
       "dev": true
     },
     "node_modules/@types/parsimmon": {
-      "version": "1.10.6",
-      "license": "MIT"
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.9.tgz",
+      "integrity": "sha512-O2M2x1w+m7gWLen8i5DOy6tWRnbRcsW6Pke3j3HAsJUrPb4g0MgjksIUm2aqUtCYxy7Qjr3CzjjwQBzhiGn46A=="
     },
     "node_modules/@types/qs": {
       "version": "6.9.9",
@@ -3364,6 +3365,11 @@
         "node": ">=8"
       }
     },
+    "node_modules/infestines": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/infestines/-/infestines-0.4.11.tgz",
+      "integrity": "sha512-09nHagZLOYUaXKHqdV+nxEaYaD0hRlKyhQMhgTMwfbvWpMkowXf4XLZzAkLq6Y90wZ7Wqm6aMoL2trBsNNKGeg=="
+    },
     "node_modules/inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -4581,6 +4587,23 @@
       "version": "1.18.1",
       "license": "MIT"
     },
+    "node_modules/partial.lenses": {
+      "version": "14.17.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-14.17.0.tgz",
+      "integrity": "sha512-Iq+wDw5b5iwmn7b9MO+//buOqF0YoAC2Hsj+HoeG88BGeT3NkL/YwHNGDrySyX7xZSqj0LFEWwfgGSj4cSFmXQ==",
+      "dependencies": {
+        "infestines": "^0.4.11"
+      }
+    },
+    "node_modules/partial.lenses.validation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses.validation/-/partial.lenses.validation-2.0.0.tgz",
+      "integrity": "sha512-NBZhmrunQWc4Ih5pJGYPHCEJfjIITPEkYn0Z6YB8qmW0iN4ZeqN0eZTWAPAH8MxjsEGx3G+8xnTMsEHbzy0k/A==",
+      "dependencies": {
+        "infestines": "^0.4.10",
+        "partial.lenses": "^14.0.0"
+      }
+    },
     "node_modules/path-exists": {
       "version": "4.0.0",
       "dev": true,
@@ -4831,6 +4854,15 @@
       "dev": true,
       "engines": {
         "node": ">= 0.8.0"
+      }
+    },
+    "node_modules/prettier-printer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prettier-printer/-/prettier-printer-1.1.4.tgz",
+      "integrity": "sha512-gQIWF7PKVknRcMoZ4Lsqj2icc97W+Q9JTa7xQgNem07yZFzOimUPq50N5oRfKkSRBZT8QqrVW1IBEMBPWqjBgQ==",
+      "dependencies": {
+        "infestines": "^0.4.11",
+        "partial.lenses.validation": "^2.0.0"
       }
     },
     "node_modules/process-nextick-args": {
@@ -5779,8 +5811,9 @@
       }
     },
     "node_modules/unraw": {
-      "version": "2.0.1",
-      "license": "MIT"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
     },
     "node_modules/update-browserslist-db": {
       "version": "1.0.13",
@@ -5833,8 +5866,13 @@
       }
     },
     "node_modules/uuid": {
-      "version": "9.0.0",
-      "license": "MIT",
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA==",
+      "funding": [
+        "https://github.com/sponsors/broofa",
+        "https://github.com/sponsors/ctavan"
+      ],
       "bin": {
         "uuid": "dist/bin/uuid"
       }
@@ -5888,14 +5926,15 @@
       "dev": true
     },
     "node_modules/wollok-ts": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.5.tgz",
-      "integrity": "sha512-nE9M3YNDYuIA6VLhSWpwRFniESHG3GDi3t2n5y3W5nYQ/b5qDUjx9ahgoid/38Hfg9TVQH33g44ZrwrJS9axyQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.6.tgz",
+      "integrity": "sha512-Ghsj21F9AZNgoJWaIGIGZf3vfpttgm9g+dPdyZBzEs02xPx2j6Z5CY7mUGUE9k1sJgrnETn4gWcNXsjGQnKuqQ==",
       "dependencies": {
-        "@types/parsimmon": "^1.10.6",
+        "@types/parsimmon": "^1.10.8",
         "parsimmon": "^1.18.1",
-        "unraw": "^2.0.1",
-        "uuid": "9.0.0"
+        "prettier-printer": "^1.1.4",
+        "unraw": "^3.0.0",
+        "uuid": "^9.0.1"
       }
     },
     "node_modules/workerpool": {
@@ -6963,7 +7002,9 @@
       "dev": true
     },
     "@types/parsimmon": {
-      "version": "1.10.6"
+      "version": "1.10.9",
+      "resolved": "https://registry.npmjs.org/@types/parsimmon/-/parsimmon-1.10.9.tgz",
+      "integrity": "sha512-O2M2x1w+m7gWLen8i5DOy6tWRnbRcsW6Pke3j3HAsJUrPb4g0MgjksIUm2aqUtCYxy7Qjr3CzjjwQBzhiGn46A=="
     },
     "@types/qs": {
       "version": "6.9.9",
@@ -8410,6 +8451,11 @@
       "integrity": "sha512-EdDDZu4A2OyIK7Lr/2zG+w5jmbuk1DVBnEwREQvBzspBJkCEbRa8GxU1lghYcaGJCnRWibjDXlq779X1/y5xwg==",
       "dev": true
     },
+    "infestines": {
+      "version": "0.4.11",
+      "resolved": "https://registry.npmjs.org/infestines/-/infestines-0.4.11.tgz",
+      "integrity": "sha512-09nHagZLOYUaXKHqdV+nxEaYaD0hRlKyhQMhgTMwfbvWpMkowXf4XLZzAkLq6Y90wZ7Wqm6aMoL2trBsNNKGeg=="
+    },
     "inflight": {
       "version": "1.0.6",
       "dev": true,
@@ -9277,6 +9323,23 @@
     "parsimmon": {
       "version": "1.18.1"
     },
+    "partial.lenses": {
+      "version": "14.17.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses/-/partial.lenses-14.17.0.tgz",
+      "integrity": "sha512-Iq+wDw5b5iwmn7b9MO+//buOqF0YoAC2Hsj+HoeG88BGeT3NkL/YwHNGDrySyX7xZSqj0LFEWwfgGSj4cSFmXQ==",
+      "requires": {
+        "infestines": "^0.4.11"
+      }
+    },
+    "partial.lenses.validation": {
+      "version": "2.0.0",
+      "resolved": "https://registry.npmjs.org/partial.lenses.validation/-/partial.lenses.validation-2.0.0.tgz",
+      "integrity": "sha512-NBZhmrunQWc4Ih5pJGYPHCEJfjIITPEkYn0Z6YB8qmW0iN4ZeqN0eZTWAPAH8MxjsEGx3G+8xnTMsEHbzy0k/A==",
+      "requires": {
+        "infestines": "^0.4.10",
+        "partial.lenses": "^14.0.0"
+      }
+    },
     "path-exists": {
       "version": "4.0.0",
       "dev": true
@@ -9457,6 +9520,15 @@
       "resolved": "https://registry.npmjs.org/prelude-ls/-/prelude-ls-1.2.1.tgz",
       "integrity": "sha512-vkcDPrRZo1QZLbn5RLGPpg/WmIQ65qoWWhcGKf/b5eplkkarX0m9z8ppCat4mlOqUsWpyNuYgO3VRyrYHSzX5g==",
       "dev": true
+    },
+    "prettier-printer": {
+      "version": "1.1.4",
+      "resolved": "https://registry.npmjs.org/prettier-printer/-/prettier-printer-1.1.4.tgz",
+      "integrity": "sha512-gQIWF7PKVknRcMoZ4Lsqj2icc97W+Q9JTa7xQgNem07yZFzOimUPq50N5oRfKkSRBZT8QqrVW1IBEMBPWqjBgQ==",
+      "requires": {
+        "infestines": "^0.4.11",
+        "partial.lenses.validation": "^2.0.0"
+      }
     },
     "process-nextick-args": {
       "version": "2.0.1"
@@ -10099,7 +10171,9 @@
       "version": "1.0.0"
     },
     "unraw": {
-      "version": "2.0.1"
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/unraw/-/unraw-3.0.0.tgz",
+      "integrity": "sha512-08/DA66UF65OlpUDIQtbJyrqTR0jTAlJ+jsnkQ4jxR7+K5g5YG1APZKQSMCE1vqqmD+2pv6+IdEjmopFatacvg=="
     },
     "update-browserslist-db": {
       "version": "1.0.13",
@@ -10127,7 +10201,9 @@
       "version": "1.0.1"
     },
     "uuid": {
-      "version": "9.0.0"
+      "version": "9.0.1",
+      "resolved": "https://registry.npmjs.org/uuid/-/uuid-9.0.1.tgz",
+      "integrity": "sha512-b+1eJOlsR9K8HJpow9Ok3fiWOWSIcIzXodvv0rQjVoOVNpWMpxf1wZNpt4y9h10odCNrqnYp1OBzRktckBe3sA=="
     },
     "v8-compile-cache-lib": {
       "version": "3.0.1",
@@ -10168,14 +10244,15 @@
       "dev": true
     },
     "wollok-ts": {
-      "version": "4.0.5",
-      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.5.tgz",
-      "integrity": "sha512-nE9M3YNDYuIA6VLhSWpwRFniESHG3GDi3t2n5y3W5nYQ/b5qDUjx9ahgoid/38Hfg9TVQH33g44ZrwrJS9axyQ==",
+      "version": "4.0.6",
+      "resolved": "https://registry.npmjs.org/wollok-ts/-/wollok-ts-4.0.6.tgz",
+      "integrity": "sha512-Ghsj21F9AZNgoJWaIGIGZf3vfpttgm9g+dPdyZBzEs02xPx2j6Z5CY7mUGUE9k1sJgrnETn4gWcNXsjGQnKuqQ==",
       "requires": {
-        "@types/parsimmon": "^1.10.6",
+        "@types/parsimmon": "^1.10.8",
         "parsimmon": "^1.18.1",
-        "unraw": "^2.0.1",
-        "uuid": "9.0.0"
+        "prettier-printer": "^1.1.4",
+        "unraw": "^3.0.0",
+        "uuid": "^9.0.1"
       }
     },
     "workerpool": {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "wollok-ts-cli",
-  "version": "0.1.2",
+  "version": "0.2.0",
   "description": "Wollok Command Line Interface",
   "repository": "https://github.com/uqbar-project/wollok-ts-cli",
   "license": "MIT",
@@ -48,7 +48,7 @@
     "p5": "^1.8.0",
     "pkg": "^5.8.1",
     "socket.io": "^4.5.1",
-    "wollok-ts": "4.0.5"
+    "wollok-ts": "4.0.6"
   },
   "devDependencies": {
     "@types/chai": "^4.3.9",


### PR DESCRIPTION
Este PR actualiza a la versión 4.0.6 de wollok-ts y resuelve dos issues: 
- instanciar wkos
- instanciar mixines

![image](https://github.com/uqbar-project/wollok-ts-cli/assets/4549002/15b9b28f-7f05-4d4c-95e6-46fe5dd46cb1)
