### PR TITLE
Fix uploading executables for ts-cli in release

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,7 @@
 name: CI build
 
 on:
-  pull_request
+  [pull_request, push]
 
 jobs:
   test:

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -4,7 +4,10 @@
 name: CI build
 
 on:
-  [pull_request, push]
+  push:
+    branches:
+      - master
+  pull_request:
 
 jobs:
   test:


### PR DESCRIPTION
Recién queriendo generar el nuevo release me di cuenta de que por un error me olvidé de volver a correr el CI para los push, y por ende el merge del PR a master no disparó la actualización de la última versión de wollok-ts-cli. La que quedó era del 4/11 que no tenía algunos arreglos que hice posteriormente (por suerte lo pude confirmar porque me lo bajé y la versión que decía era `0.1.2` y no la `0.2.0`)