### PR TITLE
fix: duplicated flushEvent on reload

### DIFF
--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -202,12 +202,13 @@ export const eventsFor = (io: Server, interpreter: Interpreter, dynamicDiagramCl
     socket.emit('images', getImages(project, assets))
     socket.emit('sizeCanvasInic', [sizeCanvas.width, sizeCanvas.height])
 
+    const flushInterval = 100
     const id = setInterval(() => {
       const gameSingleton = interpreter?.object('wollok.game.game')
       socket.emit('cellPixelSize', gameSingleton.get('cellSize')!.innerNumber!)
       try {
         interpreter.send('flushEvents', gameSingleton, interpreter.reify(timer))
-        timer += 300
+        timer += flushInterval
         // We could pass the interpreter but a program does not change it
         dynamicDiagramClient.onReload()
         if (!gameSingleton.get('running')?.innerBoolean) {
@@ -219,7 +220,7 @@ export const eventsFor = (io: Server, interpreter: Interpreter, dynamicDiagramCl
         socket.emit('errorDetected', error.message)
         clearInterval(id)
       }
-    }, 100)
+    }, flushInterval)
 
     socket.on('disconnect', () => {
       clearInterval(id)

--- a/src/commands/run.ts
+++ b/src/commands/run.ts
@@ -194,7 +194,6 @@ export const eventsFor = (io: Server, interpreter: Interpreter, dynamicDiagramCl
   const sizeCanvas = canvasResolution(interpreter)
   io.on('connection', socket => {
     logger.info(successDescription('Running game!'))
-    socket.on('disconnect', () => { logger.info(successDescription('Game finished')) })
     socket.on('keyPressed', key => {
       queueEvent(interpreter, buildKeyPressEvent(interpreter, wKeyCode(key.key, key.keyCode)), buildKeyPressEvent(interpreter, 'ANY'))
     })
@@ -221,6 +220,12 @@ export const eventsFor = (io: Server, interpreter: Interpreter, dynamicDiagramCl
         clearInterval(id)
       }
     }, 100)
+
+    socket.on('disconnect', () => {
+      clearInterval(id)
+      logger.info(successDescription('Game finished'))
+    })
+
   })
 }
 


### PR DESCRIPTION
* Cada vez que se da reload el juego empieza a andar más rápido, debido a que se acumulan los setInterval
  * Este fix agrega un clearInterval cada vez que se recibe una desconexión
  * Nota: esto no soluciona el caso de que se abran dos solapas
* también se corrige una diferencia en el `setInterval` que llama a `flushEvent`: el setInterval se ejecutaba cada 100ms, pero el timer que se pasaba a wollok incrementaba en 300 ms, esto provocaba que los `onTick` no se ejecuten correctamente
