### PR TITLE
Test options exact match

### DIFF
--- a/examples/init-examples/existing-folder/package.json
+++ b/examples/init-examples/existing-folder/package.json
@@ -2,6 +2,6 @@
   "name": "existing-folder",
   "version": "1.0.0",
   "wollokVersion": "4.0.0",
-  "author": "palumbon",
+  "author": "ivanjawerbaum",
   "license": "ISC"
 }

--- a/examples/test-examples/normal-case/test-one.wtest
+++ b/examples/test-examples/normal-case/test-one.wtest
@@ -9,4 +9,8 @@ describe "this describe" {
     assert.equals(2, a)
   }
 
+  test "another test with longer name" {
+    assert.equals("aaa", "aaa")
+  }
+
 }

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -29,7 +29,7 @@ export function getTarget(environment: Environment, filter: string | undefined, 
   if(filter){
     return getTargetByFilter(environment, filter)
   } else {
-    return getTargetByOptions(environment, options)
+    return getTargetByPreciseOptions(environment, options)
   }
 }
 
@@ -42,13 +42,12 @@ function getTargetByFilter(environment: Environment, filter: string | undefined)
 }
 
 
-function getTargetByOptions(environment: Environment, { file, describe, test }: Options): Test[] {
+function getTargetByPreciseOptions(environment: Environment, { file, describe, test }: Options): Test[] {
   let nodeToFilter: Environment | Package | Describe = environment
 
   if(file) {
     nodeToFilter = environment.descendants.find(node => node.is(Package) && node.name === file) as Package | undefined ?? environment
   }
-
   if(describe) {
     nodeToFilter = nodeToFilter.descendants.find(node => node.is(Describe) && node.name === `"${describe}"`) as Describe | undefined ?? nodeToFilter
   }
@@ -59,11 +58,9 @@ function getTargetByOptions(environment: Environment, { file, describe, test }: 
 
   const matchedTests = nodeToFilter.descendants.filter(testFilter)
 
-  if(matchedTests.some(test => test.isOnly)) {
-    return [matchedTests.find(test => test.isOnly)!]
-  }
+  const onlyTest = matchedTests.find(test => test.isOnly)
 
-  return matchedTests
+  return onlyTest ? [onlyTest] : matchedTests
 }
 
 export function tabulationForNode({ fullyQualifiedName }: { fullyQualifiedName: string }): string {

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -25,10 +25,6 @@ export function sanitize(value?: string): string | undefined {
   return value?.replaceAll('"', '')
 }
 
-export function sanitize(value?: string): string | undefined {
-  return value?.replaceAll('"', '')
-}
-
 export function getTarget(environment: Environment, filter: string | undefined, options: Options): Test[] {
   const possibleTargets = getBaseNode(environment, filter, options).descendants.filter(getTestFilter(filter, options))
   const onlyTarget = possibleTargets.find((test: Test) => test.isOnly)

--- a/src/commands/test.ts
+++ b/src/commands/test.ts
@@ -39,10 +39,10 @@ function getBaseNode(environment: Environment, filter: string | undefined, optio
   const { file, describe } = options
   let nodeToFilter: Environment | Package | Describe = environment
   if (file) {
-    nodeToFilter = environment.descendants.find(node => node.is(Package) && node.name === file) as Package | undefined ?? nodeToFilter
+    nodeToFilter = nodeToFilter.descendants.find(node => node.is(Package) && node.name === file) as Package | undefined ?? nodeToFilter
   }
   if (describe) {
-    nodeToFilter = environment.descendants.find(node => node.is(Describe) && node.name === `"${describe}"`) as Describe | undefined ?? nodeToFilter
+    nodeToFilter = nodeToFilter.descendants.find(node => node.is(Describe) && node.name === `"${describe}"`) as Describe | undefined ?? nodeToFilter
   }
   return nodeToFilter
 }

--- a/test/test.test.ts
+++ b/test/test.test.ts
@@ -30,122 +30,127 @@ describe('Test', () => {
         environment = await buildEnvironmentForProject(projectPath)
       })
 
-      it('should filter by test using filter option', () => {
-        const tests = getTarget(environment, 'another test', emptyOptions)
-        expect(tests.length).to.equal(2)
-        expect(tests[0].name).to.equal('"another test"')
-        expect(tests[1].name).to.equal('"another test with longer name"')
-      })
-
-      it('should filter by test using filter option - case insensitive', () => {
-        const tests = getTarget(environment, 'aNothEr Test', emptyOptions)
-        expect(tests.length).to.equal(0)
-      })
-
-      it('should filter by test using test option', () => {
-        const tests = getTarget(environment, undefined, {
-          ...emptyOptions,
-          test: 'another test',
+      describe('using filter option', () => {
+        it('should filter by test using filter option', () => {
+          const tests = getTarget(environment, 'another test', emptyOptions)
+          expect(tests.length).to.equal(2)
+          expect(tests[0].name).to.equal('"another test"')
+          expect(tests[1].name).to.equal('"another test with longer name"')
         })
-        expect(tests.length).to.equal(1)
-        expect(tests[0].name).to.equal('"another test"')
-      })
 
-      it('should filter by test using test option - case sensitive', () => {
-        const tests = getTarget(environment, undefined, {
-          ...emptyOptions,
-          test: 'aNother Test',
+        it('should filter by test using filter option - case insensitive', () => {
+          const tests = getTarget(environment, 'aNothEr Test', emptyOptions)
+          expect(tests.length).to.equal(0)
         })
-        expect(tests.length).to.equal(0)
-      })
 
-      it('should filter by describe using filter option', () => {
-        const tests = getTarget(environment, 'second describe', emptyOptions)
-        expect(tests.length).to.equal(2)
-        expect(tests[0].name).to.equal('"second test"')
-        expect(tests[1].name).to.equal('"another second test"')
-      })
-
-      it('should filter by describe using filter option - case insensitive', () => {
-        const tests = getTarget(environment, 'SeCOND describe', emptyOptions)
-        expect(tests.length).to.equal(0)
-      })
-
-      it('should filter by describe using describe option', () => {
-        const tests = getTarget(environment, undefined, {
-          ...emptyOptions,
-          describe: 'second describe',
+        it('should filter by describe using filter option', () => {
+          const tests = getTarget(environment, 'second describe', emptyOptions)
+          expect(tests.length).to.equal(2)
+          expect(tests[0].name).to.equal('"second test"')
+          expect(tests[1].name).to.equal('"another second test"')
         })
-        expect(tests.length).to.equal(2)
-        expect(tests[0].name).to.equal('"second test"')
-        expect(tests[1].name).to.equal('"another second test"')
-      })
 
-      it('should filter by describe & test using describe & test option', () => {
-        const tests = getTarget(environment, undefined, {
-          ...emptyOptions,
-          describe: 'second describe',
-          test: 'another second test',
+        it('should filter by describe using filter option - case insensitive', () => {
+          const tests = getTarget(environment, 'SeCOND describe', emptyOptions)
+          expect(tests.length).to.equal(0)
         })
-        expect(tests.length).to.equal(1)
-        expect(tests[0].name).to.equal('"another second test"')
-      })
 
-      it('should filter by file using filter option', () => {
-        const tests = getTarget(environment, 'test-one', emptyOptions)
-        expect(tests.length).to.equal(3)
-        expect(tests[0].name).to.equal('"a test"')
-        expect(tests[1].name).to.equal('"another test"')
-        expect(tests[2].name).to.equal('"another test with longer name"')
-      })
-
-      it('should filter by file using file option', () => {
-        const tests = getTarget(environment, undefined, {
-          ...emptyOptions,
-          file: 'test-one',
+        it('should filter by file using filter option', () => {
+          const tests = getTarget(environment, 'test-one', emptyOptions)
+          expect(tests.length).to.equal(3)
+          expect(tests[0].name).to.equal('"a test"')
+          expect(tests[1].name).to.equal('"another test"')
+          expect(tests[2].name).to.equal('"another test with longer name"')
         })
-        expect(tests.length).to.equal(3)
-        expect(tests[0].name).to.equal('"a test"')
-        expect(tests[1].name).to.equal('"another test"')
-        expect(tests[2].name).to.equal('"another test with longer name"')
-      })
 
-      it('should filter by file & describe using file & describe option', () => {
-        const tests = getTarget(environment, undefined, {
-          ...emptyOptions,
-          file: 'test-one',
-          describe: 'this describe',
+        it('should filter by file & describe using filter option', () => {
+          const tests = getTarget(environment, 'test-one.this describe', emptyOptions)
+          expect(tests.length).to.equal(3)
+          expect(tests[0].name).to.equal('"a test"')
+          expect(tests[1].name).to.equal('"another test"')
+          expect(tests[2].name).to.equal('"another test with longer name"')
         })
-        expect(tests.length).to.equal(3)
-        expect(tests[0].name).to.equal('"a test"')
-        expect(tests[1].name).to.equal('"another test"')
-        expect(tests[2].name).to.equal('"another test with longer name"')
-      })
 
-      it('should filter by file & describe using filter option', () => {
-        const tests = getTarget(environment, 'test-one.this describe', emptyOptions)
-        expect(tests.length).to.equal(3)
-        expect(tests[0].name).to.equal('"a test"')
-        expect(tests[1].name).to.equal('"another test"')
-        expect(tests[2].name).to.equal('"another test with longer name"')
-      })
-
-      it('should filter by file & describe & test using file & describe & test option', () => {
-        const tests = getTarget(environment, undefined, {
-          ...emptyOptions,
-          file: 'test-one',
-          describe: 'this describe',
-          test: 'another test',
+        it('should filter by file using filter option', () => {
+          const tests = getTarget(environment, 'test-one.this describe.another test', emptyOptions)
+          expect(tests.length).to.equal(2)
+          expect(tests[0].name).to.equal('"another test"')
+          expect(tests[1].name).to.equal('"another test with longer name"')
         })
-        expect(tests.length).to.equal(1)
-        expect(tests[0].name).to.equal('"another test"')
+
       })
 
-      it('should filter by file using filter option', () => {
-        const tests = getTarget(environment, 'test-one.this describe.another test', emptyOptions)
-        expect(tests.length).to.equal(2)
-        expect(tests[0].name).to.equal('"another test"')
-        expect(tests[1].name).to.equal('"another test with longer name"')
+      describe('with file/describe/test options', () => {
+        it('should filter by test using test option', () => {
+          const tests = getTarget(environment, undefined, {
+            ...emptyOptions,
+            test: 'another test',
+          })
+          expect(tests.length).to.equal(1)
+          expect(tests[0].name).to.equal('"another test"')
+        })
+
+        it('should filter by test using test option - case sensitive', () => {
+          const tests = getTarget(environment, undefined, {
+            ...emptyOptions,
+            test: 'aNother Test',
+          })
+          expect(tests.length).to.equal(0)
+        })
+
+        it('should filter by describe using describe option', () => {
+          const tests = getTarget(environment, undefined, {
+            ...emptyOptions,
+            describe: 'second describe',
+          })
+          expect(tests.length).to.equal(2)
+          expect(tests[0].name).to.equal('"second test"')
+          expect(tests[1].name).to.equal('"another second test"')
+        })
+
+        it('should filter by describe & test using describe & test option', () => {
+          const tests = getTarget(environment, undefined, {
+            ...emptyOptions,
+            describe: 'second describe',
+            test: 'another second test',
+          })
+          expect(tests.length).to.equal(1)
+          expect(tests[0].name).to.equal('"another second test"')
+        })
+
+        it('should filter by file using file option', () => {
+          const tests = getTarget(environment, undefined, {
+            ...emptyOptions,
+            file: 'test-one',
+          })
+          expect(tests.length).to.equal(3)
+          expect(tests[0].name).to.equal('"a test"')
+          expect(tests[1].name).to.equal('"another test"')
+          expect(tests[2].name).to.equal('"another test with longer name"')
+        })
+
+        it('should filter by file & describe using file & describe option', () => {
+          const tests = getTarget(environment, undefined, {
+            ...emptyOptions,
+            file: 'test-one',
+            describe: 'this describe',
+          })
+          expect(tests.length).to.equal(3)
+          expect(tests[0].name).to.equal('"a test"')
+          expect(tests[1].name).to.equal('"another test"')
+          expect(tests[2].name).to.equal('"another test with longer name"')
+        })
+
+        it('should filter by file & describe & test using file & describe & test option', () => {
+          const tests = getTarget(environment, undefined, {
+            ...emptyOptions,
+            file: 'test-one',
+            describe: 'this describe',
+            test: 'another test',
+          })
+          expect(tests.length).to.equal(1)
+          expect(tests[0].name).to.equal('"another test"')
+        })
       })
 
     })

--- a/test/test.test.ts
+++ b/test/test.test.ts
@@ -32,8 +32,9 @@ describe('Test', () => {
 
       it('should filter by test using filter option', () => {
         const tests = getTarget(environment, 'another test', emptyOptions)
-        expect(tests.length).to.equal(1)
+        expect(tests.length).to.equal(2)
         expect(tests[0].name).to.equal('"another test"')
+        expect(tests[1].name).to.equal('"another test with longer name"')
       })
 
       it('should filter by test using filter option - case insensitive', () => {
@@ -50,7 +51,7 @@ describe('Test', () => {
         expect(tests[0].name).to.equal('"another test"')
       })
 
-      it('should filter by test using test option - case insensitive', () => {
+      it('should filter by test using test option - case sensitive', () => {
         const tests = getTarget(environment, undefined, {
           ...emptyOptions,
           test: 'aNother Test',
@@ -92,9 +93,10 @@ describe('Test', () => {
 
       it('should filter by file using filter option', () => {
         const tests = getTarget(environment, 'test-one', emptyOptions)
-        expect(tests.length).to.equal(2)
+        expect(tests.length).to.equal(3)
         expect(tests[0].name).to.equal('"a test"')
         expect(tests[1].name).to.equal('"another test"')
+        expect(tests[2].name).to.equal('"another test with longer name"')
       })
 
       it('should filter by file using file option', () => {
@@ -102,9 +104,10 @@ describe('Test', () => {
           ...emptyOptions,
           file: 'test-one',
         })
-        expect(tests.length).to.equal(2)
+        expect(tests.length).to.equal(3)
         expect(tests[0].name).to.equal('"a test"')
         expect(tests[1].name).to.equal('"another test"')
+        expect(tests[2].name).to.equal('"another test with longer name"')
       })
 
       it('should filter by file & describe using file & describe option', () => {
@@ -113,16 +116,18 @@ describe('Test', () => {
           file: 'test-one',
           describe: 'this describe',
         })
-        expect(tests.length).to.equal(2)
+        expect(tests.length).to.equal(3)
         expect(tests[0].name).to.equal('"a test"')
         expect(tests[1].name).to.equal('"another test"')
+        expect(tests[2].name).to.equal('"another test with longer name"')
       })
 
       it('should filter by file & describe using filter option', () => {
         const tests = getTarget(environment, 'test-one.this describe', emptyOptions)
-        expect(tests.length).to.equal(2)
+        expect(tests.length).to.equal(3)
         expect(tests[0].name).to.equal('"a test"')
         expect(tests[1].name).to.equal('"another test"')
+        expect(tests[2].name).to.equal('"another test with longer name"')
       })
 
       it('should filter by file & describe & test using file & describe & test option', () => {
@@ -138,8 +143,9 @@ describe('Test', () => {
 
       it('should filter by file using filter option', () => {
         const tests = getTarget(environment, 'test-one.this describe.another test', emptyOptions)
-        expect(tests.length).to.equal(1)
+        expect(tests.length).to.equal(2)
         expect(tests[0].name).to.equal('"another test"')
+        expect(tests[1].name).to.equal('"another test with longer name"')
       })
 
     })
@@ -283,23 +289,23 @@ describe('Test', () => {
       })
 
       expect(processExitSpy.callCount).to.equal(0)
-      expect(spyCalledWithSubstring(loggerInfoSpy, 'Running 2 tests')).to.be.true
-      expect(spyCalledWithSubstring(loggerInfoSpy, '2 passing')).to.be.true
+      expect(spyCalledWithSubstring(loggerInfoSpy, 'Running 3 tests')).to.be.true
+      expect(spyCalledWithSubstring(loggerInfoSpy, '3 passing')).to.be.true
       expect(spyCalledWithSubstring(loggerInfoSpy, '0 failing')).to.be.false // old version
       expect(fileLoggerInfoSpy.calledOnce).to.be.true
-      expect(fileLoggerInfoSpy.firstCall.firstArg.result).to.deep.equal({ ok: 2, failed: 0 })
+      expect(fileLoggerInfoSpy.firstCall.firstArg.result).to.deep.equal({ ok: 3, failed: 0 })
     })
 
     it('returns exit code 2 if one or more tests fail', async () => {
       await test(undefined, emptyOptions)
 
       expect(processExitSpy.calledWith(2)).to.be.true
-      expect(spyCalledWithSubstring(loggerInfoSpy, 'Running 5 tests')).to.be.true
-      expect(spyCalledWithSubstring(loggerInfoSpy, '4 passing')).to.be.true
+      expect(spyCalledWithSubstring(loggerInfoSpy, 'Running 6 tests')).to.be.true
+      expect(spyCalledWithSubstring(loggerInfoSpy, '5 passing')).to.be.true
       expect(spyCalledWithSubstring(loggerInfoSpy, '1 failing')).to.be.true
       expect(fileLoggerInfoSpy.calledOnce).to.be.true
       const fileLoggerArg = fileLoggerInfoSpy.firstCall.firstArg
-      expect(fileLoggerArg.result).to.deep.equal({ ok: 4, failed: 1 })
+      expect(fileLoggerArg.result).to.deep.equal({ ok: 5, failed: 1 })
       expect(fileLoggerArg.failures.length).to.equal(1)
     })
 


### PR DESCRIPTION
Relacionado a https://github.com/uqbar-project/wollok-lsp-ide/issues/156 cambia como se usan las opciones file/describe/test para que en vez de convertirlo en un fqn recorra el AST para encontrar un test exacto

Usado por https://github.com/uqbar-project/wollok-lsp-ide/pull/158