### PR TITLE
Fix windows tests

### DIFF
--- a/test/run.test.ts
+++ b/test/run.test.ts
@@ -82,7 +82,8 @@ describe('testing run', () => {
       const game = interpreter.object('wollok.game.game')
       interpreter.send('addVisual', game, interpreter.object('mainGame.elementoVisual'))
       io.close()
-      expect(getVisuals(game, interpreter)).to.deep.equal([{ image: join('smalls', '1.png'), position: { x: 0, y: 1 }, message: undefined }])
+      // we can't use join in the image path since it's in Wollok project
+      expect(getVisuals(game, interpreter)).to.deep.equal([{ image: 'smalls/1.png', position: { x: 0, y: 1 }, message: undefined }])
     })
 
   })


### PR DESCRIPTION
Probando el PR de Ivo corrí los tests y me saltó este error:

![image](https://github.com/uqbar-project/wollok-ts-cli/assets/4549002/a212af2b-c80f-4e39-bc2b-5983b335e12d)

Esto es porque hay un proyecto de ejemplo que tiene el path de la imagen apuntando a `smalls/1.png` y para adaptarlo a Windows tendríamos que generarlo en base al sistema operativo. Con el update simplemente asumo que usamos la barra porque el proyecto está en Linux/Mac y ya. Con lo que da que pensar, no? si dos personas laburan en un proyecto de game en distintos sistemas operativos (uno Windows) cómo se hace.

![image](https://github.com/uqbar-project/wollok-ts-cli/assets/4549002/c565ab59-4d97-46c6-aa79-38b37a87e756)

 