### PR TITLE
Fix #173 - add gitignore to wollok init

### DIFF
--- a/examples/init-examples/existing-folder/.gitignore
+++ b/examples/init-examples/existing-folder/.gitignore
@@ -1,0 +1,6 @@
+
+# Local history
+.history
+
+# Wollok Log
+*.log

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -58,6 +58,9 @@ export default function ({ project, name, noTest = false, noCI = false, game = f
   logger.info('Creating README')
   writeFileSync(join(project, 'README.md'), readme(exampleName))
 
+  logger.info('Creating Gitignore')
+  writeFileSync(join(project, '.gitignore'), gitignore)
+
   // Finish
   logger.info(green('✨ Project succesfully created. Happy coding!'))
 }
@@ -147,4 +150,12 @@ const readme = (exampleName: string) => `
 
 TODO
 
+`
+
+const gitignore = `
+# Local history
+.history
+
+# Wollok Log
+*.log
 `

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -39,6 +39,7 @@ describe('testing init', () => {
     expect(existsSync(join(project, 'package.json'))).to.be.true
     expect(existsSync(join(project, GITHUB_FOLDER, 'ci.yml'))).to.be.true
     expect(existsSync(join(project, 'README.md'))).to.be.true
+    expect(existsSync(join(project, '.gitignore'))).to.be.true
     expect(existsSync(join(project, 'mainExample.wpgm'))).to.be.false
     expect(getResourceFolder()).to.be.undefined
 
@@ -64,6 +65,7 @@ describe('testing init', () => {
     expect(existsSync(join(project, 'mainPepita.wpgm'))).to.be.true
     expect(existsSync(join(project, 'package.json'))).to.be.true
     expect(existsSync(join(project, GITHUB_FOLDER, 'ci.yml'))).to.be.true
+    expect(existsSync(join(project, '.gitignore'))).to.be.true
     expect(existsSync(join(project, 'README.md'))).to.be.true
     expect(getResourceFolder()).to.be.equal('assets')
   })
@@ -81,6 +83,7 @@ describe('testing init', () => {
     expect(existsSync(join(project, 'package.json'))).to.be.true
     expect(existsSync(join(project, 'mainPepita.wpgm'))).to.be.false
     expect(existsSync(join(project, GITHUB_FOLDER, 'ci.yml'))).to.be.false
+    expect(existsSync(join(project, '.gitignore'))).to.be.true
     expect(existsSync(join(project, 'README.md'))).to.be.true
   })
 


### PR DESCRIPTION
El wollok init ahora agrega un archivo gitignore:

```bash

# Local history
.history

# Wollok Log
*.log
```

para evitar conflictos en un trabajo grupal: va a ser problemático porque cada une tiene su propio log.