### PR TITLE
Init :: Initialize git repo and new flag `--noGit`

### DIFF
--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -13,10 +13,10 @@ export type Options = {
   noTest: boolean,
   noCI: boolean,
   game: boolean,
-  git: boolean
+  noGit: boolean
 }
 
-export default function (folder: string | undefined, { project: _project, name, noTest = false, noCI = false, game = false, git: initializeGitRepo = false }: Options): void {
+export default function (folder: string | undefined, { project: _project, name, noTest = false, noCI = false, game = false, noGit = false }: Options): void {
   const project = join(_project, folder ?? '')
 
   // Initialization
@@ -65,7 +65,7 @@ export default function (folder: string | undefined, { project: _project, name, 
   logger.info('Creating Gitignore')
   writeFileSync(join(project, '.gitignore'), gitignore)
 
-  if (initializeGitRepo) {
+  if (!noGit) {
     logger.info('Initializing Git repository')
     execSync('git init', { cwd: project })
   }

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -70,7 +70,7 @@ export default function (folder: string | undefined, { project: _project, name, 
     try {
       execSync('git init', { cwd: project })
     } catch {
-      logger.error(yellow('Error initializing git repository, please check if git is installed in your system.'))
+      logger.error(yellow('🚨 Error initializing git repository, please check if git is installed in your system.'))
     }
   }
 

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -67,7 +67,11 @@ export default function (folder: string | undefined, { project: _project, name, 
 
   if (!noGit) {
     logger.info('Initializing Git repository')
-    execSync('git init', { cwd: project })
+    try {
+      execSync('git init', { cwd: project })
+    } catch {
+      logger.error(yellow('Error initializing git repository, please check if git is installed in your system.'))
+    }
   }
 
   // Finish

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -5,6 +5,7 @@ import { basename, join } from 'node:path'
 import { userInfo } from 'os'
 import { ENTER, createFolderIfNotExists } from '../utils'
 import { PROGRAM_FILE_EXTENSION, TEST_FILE_EXTENSION, WOLLOK_FILE_EXTENSION } from 'wollok-ts'
+import { execSync } from 'node:child_process'
 
 export type Options = {
   project: string,
@@ -12,9 +13,10 @@ export type Options = {
   noTest: boolean,
   noCI: boolean,
   game: boolean,
+  git: boolean
 }
 
-export default function (folder: string | undefined, { project: _project, name, noTest = false, noCI = false, game = false }: Options): void {
+export default function (folder: string | undefined, { project: _project, name, noTest = false, noCI = false, game = false, git: initializeGitRepo = false }: Options): void {
   const project = join(_project, folder ?? '')
 
   // Initialization
@@ -62,6 +64,11 @@ export default function (folder: string | undefined, { project: _project, name, 
 
   logger.info('Creating Gitignore')
   writeFileSync(join(project, '.gitignore'), gitignore)
+
+  if (initializeGitRepo) {
+    logger.info('Initializing Git repository')
+    execSync('git init', { cwd: project })
+  }
 
   // Finish
   logger.info(green('✨ Project succesfully created. Happy coding!'))

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,7 +61,7 @@ program.command('init')
   .option('-g, --game', 'adds a game program to the project', false)
   .option('-t, --noTest', 'avoids creating a test file', false)
   .option('-c, --noCI', 'avoids creating a file for CI', false)
-  .option('-g, --git', 'initialize a git repository', false)
+  .option('-ng, --noGit', 'avoids initializing a git repository', false)
   .allowUnknownOption()
   .action(init)
 

--- a/src/index.ts
+++ b/src/index.ts
@@ -61,6 +61,7 @@ program.command('init')
   .option('-g, --game', 'adds a game program to the project', false)
   .option('-t, --noTest', 'avoids creating a test file', false)
   .option('-c, --noCI', 'avoids creating a file for CI', false)
+  .option('-g, --git', 'initialize a git repository', false)
   .allowUnknownOption()
   .action(init)
 

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -21,6 +21,7 @@ const baseOptions: Options = {
   noCI: false,
   noTest: false,
   game: false,
+  git: false,
 }
 
 describe('testing init', () => {
@@ -103,6 +104,21 @@ describe('testing init', () => {
     expect(join(customFolderProject, GITHUB_FOLDER, 'ci.yml')).to.pathExists
     expect(join(customFolderProject, 'README.md')).to.pathExists
     expect(join(customFolderProject, '.gitignore')).to.pathExists
+  })
+
+  it('should create files successfully for default values with git flag enabled and initialize a git repository', async () => {
+    init(undefined, { ...baseOptions, git: true })
+
+    expect(join(project, '.git')).to.pathExists
+    expect(join(project, '.git/HEAD')).to.pathExists
+    expect(join(project, 'example.wlk')).to.pathExists
+    expect(join(project, 'testExample.wtest')).to.pathExists
+    expect(join(project, 'package.json')).to.pathExists
+    expect(join(project, GITHUB_FOLDER, 'ci.yml')).to.pathExists
+    expect(join(project, 'README.md')).to.pathExists
+    expect(join(project, '.gitignore')).to.pathExists
+    expect(join(project, 'mainExample.wpgm')).to.pathExists
+    expect(getResourceFolder()).to.be.undefined
   })
 
   it('should exit with code 1 if folder already exists', () => {

--- a/test/init.test.ts
+++ b/test/init.test.ts
@@ -21,7 +21,7 @@ const baseOptions: Options = {
   noCI: false,
   noTest: false,
   game: false,
-  git: false,
+  noGit: false,
 }
 
 describe('testing init', () => {
@@ -38,7 +38,7 @@ describe('testing init', () => {
     sinon.restore()
   })
 
-  it('should create files successfully for default values: ci, no game & example name', async () => {
+  it('should create files successfully for default values: ci, no game, example name & git', async () => {
     init(undefined, baseOptions)
 
     expect(join(project, 'example.wlk')).to.pathExists
@@ -48,6 +48,8 @@ describe('testing init', () => {
     expect(join(project, 'README.md')).to.pathExists
     expect(join(project, '.gitignore')).to.pathExists
     expect(join(project, 'mainExample.wpgm')).to.pathExists
+    expect(join(project, '.git')).to.pathExists
+    expect(join(project, '.git/HEAD')).to.pathExists
     expect(getResourceFolder()).to.be.undefined
 
     await test(undefined, {
@@ -106,11 +108,11 @@ describe('testing init', () => {
     expect(join(customFolderProject, '.gitignore')).to.pathExists
   })
 
-  it('should create files successfully for default values with git flag enabled and initialize a git repository', async () => {
-    init(undefined, { ...baseOptions, git: true })
+  it('should skip the initialization of a git repository if notGit flag es enabled', async () => {
+    init(undefined, { ...baseOptions, noGit: true })
 
-    expect(join(project, '.git')).to.pathExists
-    expect(join(project, '.git/HEAD')).to.pathExists
+    expect(join(project, '.git')).not.to.pathExists
+    expect(join(project, '.git/HEAD')).not.to.pathExists
     expect(join(project, 'example.wlk')).to.pathExists
     expect(join(project, 'testExample.wtest')).to.pathExists
     expect(join(project, 'package.json')).to.pathExists


### PR DESCRIPTION
New option for `init` command that initializes a git repository in the freshly created project

If you want to opt out you can pass the --noGit or -ng option.

Usage example:
```sh
wollok init # initializes a git repo
wollok init --noGit # skips the git repo creation
```

This option runs the `git init` command.

~Something that i didn't test is what happens if the user does not have git installed locally.~ Tested and handled

Fixes #122
