### PR TITLE
Separate setup and test steps on wollok init CI

### DIFF
--- a/examples/init-examples/existing-folder/.github/workflows/ci.yml
+++ b/examples/init-examples/existing-folder/.github/workflows/ci.yml
@@ -10,5 +10,7 @@ jobs:
       - run: |
           wget -O wollok-ts-cli https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-linux-x64
           chmod a+x ./wollok-ts-cli
-          ./wollok-ts-cli test --skipValidations -p ./
         shell: bash
+        name: Setup Wollok CLI
+      - run: ./wollok-ts-cli test --skipValidations -p ./
+        name: Run tests

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "wollok-ts-cli",
-  "version": "0.2.11",
+  "version": "0.3.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "wollok-ts-cli",
-      "version": "0.2.11",
+      "version": "0.3.0",
       "license": "MIT",
       "dependencies": {
         "@badisi/latest-version": "^7.0.10",

--- a/src/commands/init.ts
+++ b/src/commands/init.ts
@@ -153,8 +153,10 @@ jobs:
       - run: |
           wget -O wollok-ts-cli https://github.com/uqbar-project/wollok-ts-cli/releases/latest/download/wollok-ts-cli-linux-x64
           chmod a+x ./wollok-ts-cli
-          ./wollok-ts-cli test --skipValidations -p ./
         shell: bash
+        name: Setup Wollok CLI
+      - run: ./wollok-ts-cli test --skipValidations -p ./
+        name: Run tests
 `
 
 const readme = (exampleName: string) => `


### PR DESCRIPTION
Creo que esto va a quedar mas claro en los CIs porque antes el `wget` generaba un monton de lineas por la descarga y el resultado de los tests quedaban hundidos en esos logs.