### PR TITLE
Agregar soporte para buildear y publicar una imagen de docker cuando se publica un nuevo tag

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,3 @@
+node_modules/
+Dockerfile
+.dockerignore

--- a/.dockerignore
+++ b/.dockerignore
@@ -1,3 +1,0 @@
-node_modules/
-Dockerfile
-.dockerignore

--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -1,0 +1,60 @@
+name: Build and Push Docker Image
+
+on:
+  push:
+    branches:
+      - master
+    tags:
+      - 'v*'
+  pull_request:
+    branches:
+      - master
+
+env:
+  REGISTRY: ghcr.io
+  IMAGE_NAME: ${{ github.repository }}
+
+jobs:
+  build-and-push:
+    runs-on: ubuntu-latest
+    permissions:
+      contents: read
+      packages: write
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Log in to Container Registry
+        uses: docker/login-action@v3
+        with:
+          registry: ${{ env.REGISTRY }}
+          username: ${{ github.actor }}
+          password: ${{ secrets.GITHUB_TOKEN }}
+
+      - name: Extract metadata
+        id: meta
+        uses: docker/metadata-action@v5
+        with:
+          images: ${{ env.REGISTRY }}/${{ env.IMAGE_NAME }}
+          tags: |
+            type=ref,event=branch
+            type=ref,event=pr
+            type=semver,pattern={{version}}
+            type=semver,pattern={{major}}.{{minor}}
+            type=semver,pattern={{major}}
+            type=raw,value=latest,enable={{is_default_branch}}
+
+      - name: Set up Docker Buildx
+        uses: docker/setup-buildx-action@v3
+
+      - name: Build and push Docker image
+        uses: docker/build-push-action@v5
+        with:
+          context: .
+          platforms: linux/amd64,linux/arm64
+          push: true
+          tags: ${{ steps.meta.outputs.tags }}
+          labels: ${{ steps.meta.outputs.labels }}
+          cache-from: type=gha
+          cache-to: type=gha,mode=max

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,36 +1,30 @@
-# Use Node.js 18 LTS as base image
 FROM node:20-alpine AS builder
 
-# Set working directory
 WORKDIR /app
 
-# Copy package files
 COPY package*.json ./
 COPY scripts ./scripts
 
-# Install dependencies
 RUN npm ci
 
-# Copy source code
-COPY . .
+COPY ./src ./src
+COPY ./eslint.config.js ./eslint.config.js
+COPY ./tsconfig.build.json ./tsconfig.build.json
+COPY ./tsconfig.json ./tsconfig.json
+COPY ./public ./public
 
-# Build the application
 RUN npm run build
 
-# Create final runtime image
 FROM node:20-alpine
 
-# Set working directory
 WORKDIR /opt/wollok-ts-cli
 
-# Copy built application from builder stage
 COPY --from=builder /app/scripts ./scripts
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/public ./public
 COPY --from=builder /app/node_modules ./node_modules
 COPY --from=builder /app/package*.json ./
 
-# Create symlink for global access
 RUN npm link
 
 WORKDIR /work

--- a/Dockerfile
+++ b/Dockerfile
@@ -9,7 +9,7 @@ COPY package*.json ./
 COPY scripts ./scripts
 
 # Install dependencies
-RUN npm install
+RUN npm ci
 
 # Copy source code
 COPY . .

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,40 @@
+# Use Node.js 18 LTS as base image
+FROM node:20-alpine AS builder
+
+# Set working directory
+WORKDIR /app
+
+# Copy package files
+COPY package*.json ./
+COPY scripts ./scripts
+
+# Install dependencies
+RUN npm install
+
+# Copy source code
+COPY . .
+
+# Build the application
+RUN npm run build
+
+# Create final runtime image
+FROM node:20-alpine
+
+# Set working directory
+WORKDIR /opt/wollok-ts-cli
+
+# Copy built application from builder stage
+COPY --from=builder /app/scripts ./scripts
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/public ./public
+COPY --from=builder /app/node_modules ./node_modules
+COPY --from=builder /app/package*.json ./
+
+# Create symlink for global access
+RUN npm link
+
+WORKDIR /work
+
+ENTRYPOINT ["wollok"]
+
+CMD ["test"]

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,4 +1,4 @@
-FROM node:20-alpine AS builder
+FROM node:22-alpine AS builder
 
 WORKDIR /app
 
@@ -15,7 +15,7 @@ COPY ./public ./public
 
 RUN npm run build
 
-FROM node:20-alpine
+FROM node:22-alpine
 
 WORKDIR /opt/wollok-ts-cli
 


### PR DESCRIPTION
No estoy seguro como integrar esto al build actual, no le di nada de pensamiento porque me parecio que era un tema que depende más que nada de lo que les sea mas cómodo a ustedes.

Se me ocurre que esto podría usarse con devcontainers de vscode pero la verdad no es el caso de uso que tenia en mente.

Esto realmente acelera muchisimo el CI, por lo que vi baja el tiempo de 2m a 3s, realmente hace mucho la diferencia dado que wollok no tiene dependencias externas.