### PR TITLE
Remove docker image from PRs on CI

### DIFF
--- a/.github/workflows/docker.yml
+++ b/.github/workflows/docker.yml
@@ -6,9 +6,6 @@ on:
       - master
     tags:
       - 'v*'
-  pull_request:
-    branches:
-      - master
 
 env:
   REGISTRY: ghcr.io


### PR DESCRIPTION
Porque los builds tardan, con que se haga con las versiones de master entiendo que estamos bien